### PR TITLE
Add TravisCI support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,9 +22,11 @@ install:
   - pip3 install --upgrade pip
   - if [ "$TRAVIS_OS_NAME" = "osx" ] || [ "$TRAVIS_OS_NAME" = "windows" ] ; then pip3 install --user --upgrade setuptools wheel ; else pip3 install --upgrade setuptools wheel ; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ] || [ "$TRAVIS_OS_NAME" = "windows" ] ; then pip3 install --user -r requirements.txt ; else pip3 install -r requirements.txt ; fi
+  - python3 setup.py bdist_wheel || python setup.py bdist_wheel
   - python3 setup.py install || python setup.py install
+
+before_script:
   - python3 tests/nbt_tests.py || python tests/nbt_tests.py
-  - python3 setup.py sdist bdist_wheel || python setup.py sdist bdist_wheel
 
 deploy:
   provider: releases

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,12 +16,25 @@ matrix:
         - python -m pip install --upgrade pip
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 
+before_install: export AMULET_NBT_VERSION=$TRAVIS_TAG
+
 install:
   - pip3 install --upgrade pip
   - if [ "$TRAVIS_OS_NAME" = "osx" ] || [ "$TRAVIS_OS_NAME" = "windows" ] ; then pip3 install --user --upgrade setuptools wheel ; else pip3 install --upgrade setuptools wheel ; fi
   - if [ "$TRAVIS_OS_NAME" = "osx" ] || [ "$TRAVIS_OS_NAME" = "windows" ] ; then pip3 install --user -r requirements.txt ; else pip3 install -r requirements.txt ; fi
-  - python3 setup.py bdist_wheel || python setup.py bdist_wheel
-
-script:
   - python3 setup.py install || python setup.py install
   - python3 tests/nbt_tests.py || python tests/nbt_tests.py
+  - python3 setup.py sdist bdist_wheel || python setup.py sdist bdist_wheel
+
+deploy:
+  provider: releases
+  api_key: $GITHUB_TOKEN
+  name: "Amulet NBT $TRAVIS_TAG"
+  prerelease: true
+  skip_cleanup: true
+  file_glob: true
+  file: dist/*
+  draft: true
+  on:
+    branch: master
+    tags: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - python3 setup.py bdist_wheel || python setup.py bdist_wheel
   - python3 setup.py install || python setup.py install
 
-before_script:
+script:
   - python3 tests/nbt_tests.py || python tests/nbt_tests.py
 
 deploy:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ lanuage: python
 matrix:
   include:
     - name: "Python 3.7.1 on Linux"
-      python: 3.7
+      python: 3.7.1
     - name: "Python 3.7.4 on macOS"
       os: osx
       osx_image: xcode11
@@ -17,7 +17,7 @@ matrix:
 
 install:
   - pip3 install --upgrade pip
-  - pip3 install --user ---upgrade setuptools wheel
+  - pip3 install --user --upgrade setuptools wheel
   - pip3 install --user -r requirements.txt
   - python3 setup.py bdist_wheel || python setup.py bdist_wheel
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,25 @@
+lanuage: python
+matrix:
+  include:
+    - name: "Python 3.7.1 on Linux"
+      python: 3.7
+    - name: "Python 3.7.4 on macOS"
+      os: osx
+      osx_image: xcode11
+      language: shell
+    - name: "Python 3.7.4 on Windows"
+      os: windows
+      language: shell
+      before_install:
+        - choco install python
+        - python -m pip install --upgrade pip
+      env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
+
+install:
+  - pip3 install --upgrade pip
+  - pip3 install --user ---upgrade setuptools wheel
+  - pip3 install --user -r requirements.txt
+  - python3 setup.py bdist_wheel || python setup.py bdist_wheel
+
+script:
+  - python3 tests/nbt_tests.py || python tests/nbt_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ matrix:
 install:
   - pip3 install --upgrade pip
   - if [ "$TRAVIS_OS_NAME" = "osx" ] || [ "$TRAVIS_OS_NAME" = "windows" ] ; then pip3 install --user --upgrade setuptools wheel ; else pip3 install --upgrade setuptools wheel ; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx" ] || [ "$TRAVIS_OS_NAME" = "windows" ] ; then pip3 install --user -r requirements.txt ; else pip3 install --upgrade setuptools wheel ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ] || [ "$TRAVIS_OS_NAME" = "windows" ] ; then pip3 install --user -r requirements.txt ; else pip3 install -r requirements.txt ; fi
   - python3 setup.py bdist_wheel || python setup.py bdist_wheel
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,8 @@ matrix:
 
 install:
   - pip3 install --upgrade pip
-  - if [ "$TRAVIS_OS_NAME" = "osx"] || [ "$TRAVIS_OS_NAME" = "windows"] ; then pip3 install --user --upgrade setuptools wheel ; else pip3 install --upgrade setuptools wheel ; fi
-  - if [ "$TRAVIS_OS_NAME" = "osx"] || [ "$TRAVIS_OS_NAME" = "windows"] ; then pip3 install --user -r requirements.txt ; else pip3 install --upgrade setuptools wheel ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ] || [ "$TRAVIS_OS_NAME" = "windows" ] ; then pip3 install --user --upgrade setuptools wheel ; else pip3 install --upgrade setuptools wheel ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx" ] || [ "$TRAVIS_OS_NAME" = "windows" ] ; then pip3 install --user -r requirements.txt ; else pip3 install --upgrade setuptools wheel ; fi
   - python3 setup.py bdist_wheel || python setup.py bdist_wheel
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,8 @@ matrix:
   include:
     - name: "Python 3.7.1 on Linux"
       python: 3.7.1
+      before_install:
+        - alias pip3="python -m pip"
     - name: "Python 3.7.4 on macOS"
       os: osx
       osx_image: xcode11
@@ -22,4 +24,5 @@ install:
   - python3 setup.py bdist_wheel || python setup.py bdist_wheel
 
 script:
+  - python3 setup.py install || python setup.py install
   - python3 tests/nbt_tests.py || python tests/nbt_tests.py

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ matrix:
   include:
     - name: "Python 3.7.1 on Linux"
       python: 3.7.1
+      language: python
       before_install:
-        - alias pip3="python -m pip"
+        - pip install six || python -m pip install six || pip3 install six
     - name: "Python 3.7.4 on macOS"
       os: osx
       osx_image: xcode11

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,6 @@ matrix:
     - name: "Python 3.7.1 on Linux"
       python: 3.7.1
       language: python
-      before_install:
-        - pip install six || python -m pip install six || pip3 install six
     - name: "Python 3.7.4 on macOS"
       os: osx
       osx_image: xcode11
@@ -20,8 +18,8 @@ matrix:
 
 install:
   - pip3 install --upgrade pip
-  - pip3 install --user --upgrade setuptools wheel
-  - pip3 install --user -r requirements.txt
+  - if [ "$TRAVIS_OS_NAME" = "osx"] || [ "$TRAVIS_OS_NAME" = "windows"] ; then pip3 install --user --upgrade setuptools wheel ; else pip3 install --upgrade setuptools wheel ; fi
+  - if [ "$TRAVIS_OS_NAME" = "osx"] || [ "$TRAVIS_OS_NAME" = "windows"] ; then pip3 install --user -r requirements.txt ; else pip3 install --upgrade setuptools wheel ; fi
   - python3 setup.py bdist_wheel || python setup.py bdist_wheel
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ deploy:
   prerelease: true
   skip_cleanup: true
   file_glob: true
-  file: dist/*
+  file: dist/*.whl
   draft: true
   on:
     branch: master

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,12 +11,12 @@ matrix:
     - name: "Python 3.7.4 on Windows"
       os: windows
       language: shell
-      before_install:
-        - choco install python
-        - python -m pip install --upgrade pip
       env: PATH=/c/Python37:/c/Python37/Scripts:$PATH
 
-before_install: export AMULET_NBT_VERSION=$TRAVIS_TAG
+before_install:
+  - if [ "$TRAVIS_OS_NAME" = "windows" ] ; then choco install python ; fi
+  - if [ "$TRAVIS_OS_NAME" = "windows" ] ; then python -m pip install --upgrade pip ; fi
+  - export AMULET_NBT_VERSION=$TRAVIS_TAG
 
 install:
   - pip3 install --upgrade pip

--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,12 @@ extensions = [
     )
 ]
 
+module_version = os.environ.get("AMULET_NBT_VERSION", "0.0.0")
+module_version = module_version if module_version else "0.0.0"
+
 setup(
     name="amulet_nbt",
-    version=os.environ.get("AMULET_NBT_VERSION", "0.0.0"),
+    version=module_version,
     packages=packages,
     package_dir={"": "src"},
     include_dirs=include_dirs,

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ extensions = [
 
 setup(
     name="amulet_nbt",
-    version="0.0.0",
+    version=os.environ.get("AMULET_NBT_VERSION", "0.0.0"),
     packages=packages,
     package_dir={"": "src"},
     include_dirs=include_dirs,

--- a/src/amulet_nbt/__init__.py
+++ b/src/amulet_nbt/__init__.py
@@ -1,13 +1,4 @@
-import traceback
-
 try:
     from .amulet_cy_nbt import *
-
-    if __debug__:
-        print("Using Amulet NBT library")
 except (ImportError, ModuleNotFoundError) as e:
     from .amulet_py_nbt import *
-
-    if __debug__:
-        traceback.print_exc()
-        print("Using pure python NBT library")


### PR DESCRIPTION
Automatically compiles and run tests for both regular python and cython versions of our NBT library on Windows, OSX, and Linux. When a Git tag is added to a commit, the build artifacts will be uploaded to a new Github Release page .

### Changes

- Added `.travis.yml` file
  - Configuration for testing and building of the library
- Module versioning not has a default value of `0.0.0` unless the build was trigged by a Git tag
  - The value of the Git tag will be the release number built into the package/module
- Removed unnecessary print statements in `__init__.py`