### PR TITLE
Merge fixes for massive_nbt_test

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -43,6 +43,7 @@ jobs:
           command: |
             . venv/bin/activate
             python ./tests/nbt_tests.py -v
+            python ./tests/massive_nbt_test.py
 
 #      - run:
 #          name: run stylecheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,7 @@ install:
 
 script:
   - python3 tests/nbt_tests.py || python tests/nbt_tests.py
+  - python3 tests/massive_nbt_test.py || python tests/massive_nbt_test.py
 
 deploy:
   provider: releases

--- a/src/amulet_nbt/amulet_cy_nbt.pyx
+++ b/src/amulet_nbt/amulet_cy_nbt.pyx
@@ -310,25 +310,18 @@ cdef class _TAG_Array(_TAG_Value):
     def __len__(self):
         return len(self.value)
 
-    def is_little_endian(self):
-        '''
-        Note: for `TAG_Byte_Array` objects, this will always evaluate to True
-        :return: True if the array is little endian, False if it is big endian
-        '''
-        return self.data_type == self.little_endian_data_type
-
 cdef class TAG_Byte_Array(_TAG_Array):
-    big_endian_data_type = little_endian_data_type = data_type = numpy.dtype("int8")
+    big_endian_data_type = little_endian_data_type = numpy.dtype("int8")
 
     def __cinit__(self):
         self.tag_id = _ID_BYTE_ARRAY
 
     def __init__(self, object value = None):
         if value is None:
-            value = numpy.zeros((0,), self.data_type)
+            value = numpy.zeros((0,), self.big_endian_data_type)
 
         if isinstance(value, list):
-            value = numpy.array(value, self.data_type)
+            value = numpy.array(value, self.big_endian_data_type)
 
         self.value = value
 
@@ -340,13 +333,10 @@ cdef class TAG_Byte_Array(_TAG_Array):
         return f"[B;{'B, '.join(tags)}B]"
 
     cdef void save_value(self, buffer, little_endian):
-        #print("Byte_Array", self.data_type)
-        #print(self.value)
-        #print(type(self.value))
-        #print('-' * 16)
-        if self.value.dtype != self.data_type:
-            print(f'[Warning] Mismatch array dtype. Expected: {self.data_type.str}, got: {self.value.dtype.str}')
-            self.value = self.value.astype(self.data_type)
+        data_type = self.little_endian_data_type if little_endian else self.big_endian_data_type
+        if self.value.dtype != data_type:
+            print(f'[Warning] Mismatch array dtype. Expected: {data_type.str}, got: {self.value.dtype.str}')
+            self.value = self.value.astype(data_type)
         save_array(self.value, buffer, 1, little_endian)
 
 cdef class TAG_Int_Array(_TAG_Array):
@@ -356,13 +346,12 @@ cdef class TAG_Int_Array(_TAG_Array):
     def __cinit__(self):
         self.tag_id = _ID_INT_ARRAY
 
-    def __init__(self, object value = None, bint little_endian = False):
-        self.data_type = self.little_endian_data_type if little_endian else self.big_endian_data_type
+    def __init__(self, object value = None):
         if value is None:
-            value = numpy.zeros((0,), self.data_type)
+            value = numpy.zeros((0,), self.big_endian_data_type)
 
         if isinstance(value, list):
-            value = numpy.array(value, self.data_type)
+            value = numpy.array(value, self.big_endian_data_type)
 
         self.value = value
 
@@ -374,9 +363,10 @@ cdef class TAG_Int_Array(_TAG_Array):
         return f"[I;{', '.join(tags)}]"
 
     cdef void save_value(self, buffer, little_endian):
-        if self.value.dtype != self.data_type:
-            print(f'[Warning] Mismatch array dtype. Expected: {self.data_type.str}, got: {self.value.dtype.str}')
-            self.value = self.value.astype(self.data_type)
+        data_type = self.little_endian_data_type if little_endian else self.big_endian_data_type
+        if self.value.dtype != data_type:
+            print(f'[Warning] Mismatch array dtype. Expected: {data_type.str}, got: {self.value.dtype.str}')
+            self.value = self.value.astype(data_type)
         save_array(self.value, buffer, 4, little_endian)
 
 cdef class TAG_Long_Array(_TAG_Array):
@@ -386,14 +376,12 @@ cdef class TAG_Long_Array(_TAG_Array):
     def __cinit__(self):
         self.tag_id = _ID_LONG_ARRAY
 
-    def __init__(self, object value = None, bint little_endian = False):
-        self.data_type = self.little_endian_data_type if little_endian else self.big_endian_data_type
-
+    def __init__(self, object value = None):
         if value is None:
-            value = numpy.zeros((0,), self.data_type)
+            value = numpy.zeros((0,), self.big_endian_data_type)
 
         if isinstance(value, list):
-            value = numpy.array(value, self.data_type)
+            value = numpy.array(value, self.big_endian_data_type)
 
         self.value = value
 
@@ -405,9 +393,10 @@ cdef class TAG_Long_Array(_TAG_Array):
         return f"[L;{', '.join(tags)}]"
 
     cdef void save_value(self, buffer, little_endian):
-        if self.value.dtype != self.data_type:
-            print(f'[Warning] Mismatch array dtype. Expected: {self.data_type.str}, got: {self.value.dtype.str}')
-            self.value = self.value.astype(self.data_type)
+        data_type = self.little_endian_data_type if little_endian else self.big_endian_data_type
+        if self.value.dtype != data_type:
+            print(f'[Warning] Mismatch array dtype. Expected: {data_type.str}, got: {self.value.dtype.str}')
+            self.value = self.value.astype(data_type)
         save_array(self.value, buffer, 8, little_endian)
 
 cdef class _TAG_List(_TAG_Value):
@@ -722,7 +711,8 @@ cdef TAG_Byte_Array load_byte_array(buffer_context context, bint little_endian):
 
     byte_length = length
     cdef char*arr = read_data(context, byte_length)
-    return TAG_Byte_Array(numpy.frombuffer(arr[:byte_length], dtype=TAG_Byte_Array.data_type, count=length))
+    data_type = TAG_Byte_Array.little_endian_data_type if little_endian else TAG_Byte_Array.big_endian_data_type
+    return TAG_Byte_Array(numpy.frombuffer(arr[:byte_length], dtype=data_type, count=length))
 
 cdef TAG_Int_Array load_int_array(buffer_context context, bint little_endian):
     cdef int*pointer = <int*> read_data(context, 4)
@@ -741,7 +731,7 @@ cdef TAG_Long_Array load_long_array(buffer_context context, bint little_endian):
 
     byte_length = length * 8
     cdef char*arr = read_data(context, byte_length)
-    cdef object data_type = TAG_Int_Array.little_endian_data_type if little_endian else TAG_Int_Array.big_endian_data_type
+    cdef object data_type = TAG_Long_Array.little_endian_data_type if little_endian else TAG_Long_Array.big_endian_data_type
     return TAG_Long_Array(numpy.frombuffer(arr[:byte_length], dtype=data_type, count=length))
 
 cdef _TAG_List load_list(buffer_context context, bint little_endian):
@@ -970,7 +960,7 @@ cdef tuple _parse_snbt_recursive(str snbt, int index=0):
                     index = match.end()
 
                 index = _strip_comma(snbt, index, ']')
-            data = array_type(numpy.asarray(array, dtype=array_type.data_type))
+            data = array_type(numpy.asarray(array, dtype=array_type.big_endian_data_type))
         else:
             # list
             array = []

--- a/src/amulet_nbt/amulet_cy_nbt.pyx
+++ b/src/amulet_nbt/amulet_cy_nbt.pyx
@@ -147,7 +147,6 @@ cpdef bytes safe_gunzip(bytes data):
     return data
 
 cdef class _TAG_Value:
-    cdef dict __dict__
     cdef public char tag_id
 
     def copy(self):

--- a/tests/massive_nbt_test.py
+++ b/tests/massive_nbt_test.py
@@ -1,106 +1,108 @@
-import amulet_nbt
+import amulet_nbt.amulet_py_nbt as pynbt
+import amulet_nbt.amulet_cy_nbt as cynbt
 import numpy
 
-test_ = amulet_nbt.NBTFile(value=amulet_nbt.TAG_Compound(), name='hello')
+for amulet_nbt in (pynbt, cynbt):
+    test_ = amulet_nbt.NBTFile(value=amulet_nbt.TAG_Compound(), name='hello')
 
-test = amulet_nbt.NBTFile(name='hello')  # fill with an empty compound if not defined
+    test = amulet_nbt.NBTFile(name='hello')  # fill with an empty compound if not defined
 
-# the nbt objects with no inputs
-test['emptyByte'] = amulet_nbt.TAG_Byte()
-test['emptyShort'] = amulet_nbt.TAG_Short()
-test['emptyInt'] = amulet_nbt.TAG_Int()
-test['emptyLong'] = amulet_nbt.TAG_Long()
-test['emptyFloat'] = amulet_nbt.TAG_Float()
-test['emptyDouble'] = amulet_nbt.TAG_Double()
-test['emptyByteArray'] = amulet_nbt.TAG_Byte_Array()
-test['emptyString'] = amulet_nbt.TAG_String()
-test['emptyList'] = amulet_nbt.TAG_List()
-test['emptyCompound'] = amulet_nbt.TAG_Compound()
-test['emptyIntArray'] = amulet_nbt.TAG_Int_Array()
-test['emptyLongArray'] = amulet_nbt.TAG_Long_Array()
+    # the nbt objects with no inputs
+    test['emptyByte'] = amulet_nbt.TAG_Byte()
+    test['emptyShort'] = amulet_nbt.TAG_Short()
+    test['emptyInt'] = amulet_nbt.TAG_Int()
+    test['emptyLong'] = amulet_nbt.TAG_Long()
+    test['emptyFloat'] = amulet_nbt.TAG_Float()
+    test['emptyDouble'] = amulet_nbt.TAG_Double()
+    test['emptyByteArray'] = amulet_nbt.TAG_Byte_Array()
+    test['emptyString'] = amulet_nbt.TAG_String()
+    test['emptyList'] = amulet_nbt.TAG_List()
+    test['emptyCompound'] = amulet_nbt.TAG_Compound()
+    test['emptyIntArray'] = amulet_nbt.TAG_Int_Array()
+    test['emptyLongArray'] = amulet_nbt.TAG_Long_Array()
 
-# the nbt objects with zero or empty inputs (pure python only)
-test['zeroByte'] = amulet_nbt.TAG_Byte(0)
-test['zeroShort'] = amulet_nbt.TAG_Short(0)
-test['zeroInt'] = amulet_nbt.TAG_Int(0)
-test['zeroLong'] = amulet_nbt.TAG_Long(0)
-test['zeroFloat'] = amulet_nbt.TAG_Float(0)
-test['zeroDouble'] = amulet_nbt.TAG_Double(0)
-test['zeroByteArray'] = amulet_nbt.TAG_Byte_Array([])
-test['zeroString'] = amulet_nbt.TAG_String('')
-test['zeroList'] = amulet_nbt.TAG_List([])
-test['zeroCompound'] = amulet_nbt.TAG_Compound({})
-test['zeroIntArray'] = amulet_nbt.TAG_Int_Array([])
-test['zeroLongArray'] = amulet_nbt.TAG_Long_Array([])
+    # the nbt objects with zero or empty inputs (pure python only)
+    test['zeroByte'] = amulet_nbt.TAG_Byte(0)
+    test['zeroShort'] = amulet_nbt.TAG_Short(0)
+    test['zeroInt'] = amulet_nbt.TAG_Int(0)
+    test['zeroLong'] = amulet_nbt.TAG_Long(0)
+    test['zeroFloat'] = amulet_nbt.TAG_Float(0)
+    test['zeroDouble'] = amulet_nbt.TAG_Double(0)
+    test['zeroByteArray'] = amulet_nbt.TAG_Byte_Array([])
+    test['zeroString'] = amulet_nbt.TAG_String('')
+    test['zeroList'] = amulet_nbt.TAG_List([])
+    test['zeroCompound'] = amulet_nbt.TAG_Compound({})
+    test['zeroIntArray'] = amulet_nbt.TAG_Int_Array([])
+    test['zeroLongArray'] = amulet_nbt.TAG_Long_Array([])
 
-# empty inputs but numpy arrays for the array types
-test['zeroNumpyByteArray'] = amulet_nbt.TAG_Byte_Array(numpy.array([]))
-test['zeroNumpyIntArray'] = amulet_nbt.TAG_Int_Array(numpy.array([]))
-test['zeroNumpyLongArray'] = amulet_nbt.TAG_Long_Array(numpy.array([]))
+    # empty inputs but numpy arrays for the array types
+    test['zeroNumpyByteArray'] = amulet_nbt.TAG_Byte_Array(numpy.array([]))
+    test['zeroNumpyIntArray'] = amulet_nbt.TAG_Int_Array(numpy.array([]))
+    test['zeroNumpyLongArray'] = amulet_nbt.TAG_Long_Array(numpy.array([]))
 
-# test the array types with some python data
-test['listByteArray'] = amulet_nbt.TAG_Byte_Array([i for i in range(-128, 127)])
-test['listIntArray'] = amulet_nbt.TAG_Int_Array([i for i in range(-400, 400)])
-test['listLongArray'] = amulet_nbt.TAG_Long_Array([i for i in range(-400, 400)])
+    # test the array types with some python data
+    test['listByteArray'] = amulet_nbt.TAG_Byte_Array([i for i in range(-128, 127)])
+    test['listIntArray'] = amulet_nbt.TAG_Int_Array([i for i in range(-400, 400)])
+    test['listLongArray'] = amulet_nbt.TAG_Long_Array([i for i in range(-400, 400)])
 
-# test the array types with numpy data of varying dtypes
-test['numpyDtypeTestByteArray'] = amulet_nbt.TAG_Byte_Array(numpy.array([i for i in range(-128, 127)], dtype=numpy.int))
-test['numpyDtypeuTestByteArray'] = amulet_nbt.TAG_Byte_Array(numpy.array([i for i in range(-128, 127)], dtype=numpy.uint))
-test['numpyDtypeTestIntArray'] = amulet_nbt.TAG_Int_Array(numpy.array([i for i in range(-400, 400)], dtype=numpy.int))
-test['numpyDtypeuTestIntArray'] = amulet_nbt.TAG_Int_Array(numpy.array([i for i in range(-400, 400)], dtype=numpy.uint))
-test['numpyDtypeTestLongArray'] = amulet_nbt.TAG_Long_Array(numpy.array([i for i in range(-400, 400)], dtype=numpy.int))
-test['numpyDtypeuTestLongArray'] = amulet_nbt.TAG_Long_Array(numpy.array([i for i in range(-400, 400)], dtype=numpy.uint))
+    # test the array types with numpy data of varying dtypes
+    test['numpyDtypeTestByteArray'] = amulet_nbt.TAG_Byte_Array(numpy.array([i for i in range(-128, 127)], dtype=numpy.int))
+    test['numpyDtypeuTestByteArray'] = amulet_nbt.TAG_Byte_Array(numpy.array([i for i in range(-128, 127)], dtype=numpy.uint))
+    test['numpyDtypeTestIntArray'] = amulet_nbt.TAG_Int_Array(numpy.array([i for i in range(-400, 400)], dtype=numpy.int))
+    test['numpyDtypeuTestIntArray'] = amulet_nbt.TAG_Int_Array(numpy.array([i for i in range(-400, 400)], dtype=numpy.uint))
+    test['numpyDtypeTestLongArray'] = amulet_nbt.TAG_Long_Array(numpy.array([i for i in range(-400, 400)], dtype=numpy.int))
+    test['numpyDtypeuTestLongArray'] = amulet_nbt.TAG_Long_Array(numpy.array([i for i in range(-400, 400)], dtype=numpy.uint))
 
-test['numpyDtypedTestByteArray'] = amulet_nbt.TAG_Byte_Array(numpy.array([i for i in range(-128, 127)]))
-test['numpyDtypedTestIntArray'] = amulet_nbt.TAG_Int_Array(numpy.array([i for i in range(-400, 400)]))
-test['numpyDtypedTestLongArray'] = amulet_nbt.TAG_Long_Array(numpy.array([i for i in range(-400, 400)]))
+    test['numpyDtypedTestByteArray'] = amulet_nbt.TAG_Byte_Array(numpy.array([i for i in range(-128, 127)]))
+    test['numpyDtypedTestIntArray'] = amulet_nbt.TAG_Int_Array(numpy.array([i for i in range(-400, 400)]))
+    test['numpyDtypedTestLongArray'] = amulet_nbt.TAG_Long_Array(numpy.array([i for i in range(-400, 400)]))
 
-# test the extremes of the array types
-# byte array tested above
-test['numpyExtremeTestIntArray'] = amulet_nbt.TAG_Int_Array(numpy.array([-2**31, (2**31)-1], dtype=numpy.int))
-test['numpyExtremeTestLongArray'] = amulet_nbt.TAG_Long_Array(numpy.array([-2**63, (2**63)-1], dtype='q'))
+    # test the extremes of the array types
+    # byte array tested above
+    test['numpyExtremeTestIntArray'] = amulet_nbt.TAG_Int_Array(numpy.array([-2**31, (2**31)-1], dtype=numpy.int))
+    test['numpyExtremeTestLongArray'] = amulet_nbt.TAG_Long_Array(numpy.array([-2**63, (2**63)-1], dtype='q'))
 
-test['minByte'] = amulet_nbt.TAG_Byte(-128)
-test['minShort'] = amulet_nbt.TAG_Short(-2**15)
-test['minInt'] = amulet_nbt.TAG_Int(-2**31)
-test['minLong'] = amulet_nbt.TAG_Long(-2**63)
+    test['minByte'] = amulet_nbt.TAG_Byte(-128)
+    test['minShort'] = amulet_nbt.TAG_Short(-2**15)
+    test['minInt'] = amulet_nbt.TAG_Int(-2**31)
+    test['minLong'] = amulet_nbt.TAG_Long(-2**63)
 
-test['maxByte'] = amulet_nbt.TAG_Byte(127)
-test['maxShort'] = amulet_nbt.TAG_Short(2**15-1)
-test['maxInt'] = amulet_nbt.TAG_Int(2**31-1)
-test['maxLong'] = amulet_nbt.TAG_Long(2**63-1)
-
-
-# these should either overflow when setting or error when saving. Test each and if it errors just comment it out
-# test['overflowByte'] = amulet_nbt.TAG_Byte(300)
-# test['underflowByte'] = amulet_nbt.TAG_Byte(-300)
-# test['overflowShort'] = amulet_nbt.TAG_Short(2**16)
-# test['underflowShort'] = amulet_nbt.TAG_Short(-2**16)
-# test['overflowInt'] = amulet_nbt.TAG_Int(2**32)
-# test['underflowInt'] = amulet_nbt.TAG_Int(-2**32)
-# test['overflowLong'] = amulet_nbt.TAG_Long(2**64)
-# test['underflowLong'] = amulet_nbt.TAG_Long(-2**64)
-
-# test['overflowByteArray'] = amulet_nbt.TAG_Byte_Array([-129, 128])
-# test['overflowIntArray'] = amulet_nbt.TAG_Int_Array([-2**31-1, 2**31])
-# test['overflowLongArray'] = amulet_nbt.TAG_Long_Array([-2**63-1, 2**63])
-
-# test['overflowNumpyByteArray'] = amulet_nbt.TAG_Byte_Array(numpy.array([-129, 128]))
-# test['overflowNumpyIntArray'] = amulet_nbt.TAG_Int_Array(numpy.array([-2**31-1, 2**31]))
-# test['overflowNumpyLongArray'] = amulet_nbt.TAG_Long_Array(numpy.array([-2**63-1, 2**63]))
+    test['maxByte'] = amulet_nbt.TAG_Byte(127)
+    test['maxShort'] = amulet_nbt.TAG_Short(2**15-1)
+    test['maxInt'] = amulet_nbt.TAG_Int(2**31-1)
+    test['maxLong'] = amulet_nbt.TAG_Long(2**63-1)
 
 
-# save then load back up and check the data matches
+    # these should either overflow when setting or error when saving. Test each and if it errors just comment it out
+    # test['overflowByte'] = amulet_nbt.TAG_Byte(300)
+    # test['underflowByte'] = amulet_nbt.TAG_Byte(-300)
+    # test['overflowShort'] = amulet_nbt.TAG_Short(2**16)
+    # test['underflowShort'] = amulet_nbt.TAG_Short(-2**16)
+    # test['overflowInt'] = amulet_nbt.TAG_Int(2**32)
+    # test['underflowInt'] = amulet_nbt.TAG_Int(-2**32)
+    # test['overflowLong'] = amulet_nbt.TAG_Long(2**64)
+    # test['underflowLong'] = amulet_nbt.TAG_Long(-2**64)
 
-test.save_to('massive_nbt_test_big_endian.nbt', compressed=False)
-test.save_to('massive_nbt_test_big_endian_compressed.nbt', compressed=True)
-test.save_to('massive_nbt_test_little_endian.nbt', compressed=False, little_endian=True)
+    # test['overflowByteArray'] = amulet_nbt.TAG_Byte_Array([-129, 128])
+    # test['overflowIntArray'] = amulet_nbt.TAG_Int_Array([-2**31-1, 2**31])
+    # test['overflowLongArray'] = amulet_nbt.TAG_Long_Array([-2**63-1, 2**63])
 
-test_be = amulet_nbt.load('massive_nbt_test_big_endian.nbt')
-test_be_compressed = amulet_nbt.load('massive_nbt_test_big_endian_compressed.nbt')
-test_le = amulet_nbt.load('massive_nbt_test_little_endian.nbt', little_endian=True)
+    # test['overflowNumpyByteArray'] = amulet_nbt.TAG_Byte_Array(numpy.array([-129, 128]))
+    # test['overflowNumpyIntArray'] = amulet_nbt.TAG_Int_Array(numpy.array([-2**31-1, 2**31]))
+    # test['overflowNumpyLongArray'] = amulet_nbt.TAG_Long_Array(numpy.array([-2**63-1, 2**63]))
 
-assert test_be == test
-assert test_be_compressed == test
-assert test_le == test
-print('Finished massive nbt test without issue')
+
+    # save then load back up and check the data matches
+
+    test.save_to('massive_nbt_test_big_endian.nbt', compressed=False)
+    test.save_to('massive_nbt_test_big_endian_compressed.nbt', compressed=True)
+    test.save_to('massive_nbt_test_little_endian.nbt', compressed=False, little_endian=True)
+
+    test_be = amulet_nbt.load('massive_nbt_test_big_endian.nbt')
+    test_be_compressed = amulet_nbt.load('massive_nbt_test_big_endian_compressed.nbt')
+    test_le = amulet_nbt.load('massive_nbt_test_little_endian.nbt', little_endian=True)
+
+    assert test_be == test
+    assert test_be_compressed == test
+    assert test_le == test
+    print(f'Finished massive nbt test for {amulet_nbt.__name__} without issue\n')


### PR DESCRIPTION
Included fixes for the cython version of the library to pass all asserts in `tests\massive_nbt_test.py`

### Changes

- TAG_Array classes no longer track data type and cast the array to the appropriate endian type when saving
- Fix for keyword argument in `NBTFile`