### PR TITLE
Improved the nbt load function

### DIFF
--- a/amulet_nbt/amulet_cy_nbt.pyx
+++ b/amulet_nbt/amulet_cy_nbt.pyx
@@ -3,7 +3,7 @@ from math import trunc, floor, ceil
 import zlib
 from collections.abc import MutableMapping, MutableSequence
 from io import BytesIO
-from typing import Optional, Union, Tuple, List, Iterator
+from typing import Optional, Union, Tuple, List, Iterator, BinaryIO
 
 import numpy
 import os
@@ -1027,7 +1027,7 @@ class NBTFile:
 
 
 def load(
-    filepath_or_buffer: Union[str, bytes, BytesIO, None] = None,  # TODO: This should become a required input
+    filepath_or_buffer: Union[str, bytes, BinaryIO, None] = None,  # TODO: This should become a required input
     compressed=True,
     count: int = None,
     offset: bool = False,

--- a/amulet_nbt/amulet_cy_nbt.pyx
+++ b/amulet_nbt/amulet_cy_nbt.pyx
@@ -6,6 +6,7 @@ from io import BytesIO
 from typing import Optional, Union, Tuple, List, Iterator
 
 import numpy
+import os
 from cpython cimport PyUnicode_DecodeUTF8, PyList_Append
 
 import re
@@ -79,12 +80,21 @@ cdef str CommaNewline = ",\n"
 cdef str CommaSpace = ", "
 
 
-class NBTFormatError(ValueError):
+class NBTError(Exception):
+    """Some error in the NBT library."""
+
+
+class NBTLoadError(NBTError):
+    """The NBT data failed to load for some reason."""
+    pass
+
+
+class NBTFormatError(NBTLoadError):
     """Indicates the NBT format is invalid."""
     pass
 
 
-class SNBTParseError(Exception):
+class SNBTParseError(NBTError):
     """Indicates the SNBT format is invalid."""
     pass
 
@@ -544,7 +554,7 @@ cdef class _TAG_Array(_TAG_Value):
             if value.dtype != self.big_endian_data_type:
                 value = value.astype(self.big_endian_data_type)
         else:
-            raise Exception(f'Unexpected object {value} given to {self.__class__.__name__}')
+            raise NBTError(f'Unexpected object {value} given to {self.__class__.__name__}')
 
         self.value = value
 
@@ -959,7 +969,7 @@ class NBTFile:
     def to_snbt(self, indent_chr=None) -> str:
         return self.value.to_snbt(indent_chr)
 
-    def save_to(self, filename_or_buffer=None, compressed=True, little_endian=False) -> Optional[bytes]:
+    def save_to(self, filepath_or_buffer=None, compressed=True, little_endian=False) -> Optional[bytes]:
         buffer = BytesIO()
         self.value.write_payload(buffer, self.name, little_endian)
         data = buffer.getvalue()
@@ -970,14 +980,14 @@ class NBTFile:
                 gz.write(data)
             data = gzip_buffer.getvalue()
 
-        if not filename_or_buffer:
+        if not filepath_or_buffer:
             return data
 
-        if isinstance(filename_or_buffer, str):
-            with open(filename_or_buffer, 'wb') as fp:
+        if isinstance(filepath_or_buffer, str):
+            with open(filepath_or_buffer, 'wb') as fp:
                 fp.write(data)
         else:
-            filename_or_buffer.write(data)
+            filepath_or_buffer.write(data)
 
     def __eq__(self, other):
         return isinstance(other, NBTFile) and self.value.__eq__(other.value) and self.name == other.name
@@ -1016,21 +1026,41 @@ class NBTFile:
         return self.value.get(k, default)
 
 
-def load(filename="", buffer=None, compressed=True, count: int = None, offset: bool = False, little_endian: bool = False
-         ) -> Union[NBTFile, Tuple[Union[NBTFile, List[NBTFile]], int]]:
-    if filename:
-        if not isinstance(filename, str):
-            raise Exception("filename must be a string. If you want to load nbt from bytes use the buffer input.")
-        buffer = open(filename, "rb")
-    data_in = buffer
+def load(
+    filepath_or_buffer: Union[str, bytes, BytesIO, None] = None,  # TODO: This should become a required input
+    compressed=True,
+    count: int = None,
+    offset: bool = False,
+    little_endian: bool = False,
+    buffer=None,  # TODO: this should get depreciated and removed.
+) -> Union[NBTFile, Tuple[Union[NBTFile, List[NBTFile]], int]]:
+    if isinstance(filepath_or_buffer, str):
+        # if a string load from the file path
+        if not os.path.isfile(filepath_or_buffer):
+            raise NBTLoadError(f"There is no file at {filepath_or_buffer}")
+        with open(filepath_or_buffer, "rb") as f:
+            data_in = f.read()
+    else:
+        # TODO: when buffer is removed, remove this if block and make the next if block an elif part of the parent if block
+        if filepath_or_buffer is None:  # For backwards compatability with buffer.
+            if buffer is None:
+                raise NBTLoadError("No object given to load.")
+            filepath_or_buffer = buffer
 
-    if hasattr(buffer, "read"):
-        data_in = buffer.read()
-
-    if hasattr(buffer, "close"):
-        buffer.close()
-    elif hasattr(buffer, "open"):
-        print("[Warning]: Input buffer didn't have close() function. Memory leak may occur!")
+        if isinstance(filepath_or_buffer, bytes):
+            data_in = filepath_or_buffer
+        elif hasattr(filepath_or_buffer, "read"):
+            data_in = filepath_or_buffer.read()
+            if not isinstance(data_in, bytes):
+                raise NBTLoadError(f"buffer.read() must return a bytes object. Got {type(data_in)} instead.")
+            if hasattr(filepath_or_buffer, "close"):
+                filepath_or_buffer.close()
+            elif hasattr(filepath_or_buffer, "open"):
+                print(
+                    "[Warning]: Input buffer didn't have close() function. Memory leak may occur!"
+                )
+        else:
+            raise NBTLoadError("buffer did not have a read method.")
 
     if compressed:
         data_in = safe_gunzip(data_in)

--- a/amulet_nbt/amulet_py_nbt.py
+++ b/amulet_nbt/amulet_py_nbt.py
@@ -20,6 +20,7 @@ from typing import (
     Iterator,
     overload,
     Iterable,
+    BinaryIO,
 )
 import re
 from copy import deepcopy
@@ -1121,7 +1122,7 @@ class NBTFile:
 
 
 def load(
-    filepath_or_buffer: Union[str, bytes, BytesIO, None] = None,  # TODO: This should become a required input
+    filepath_or_buffer: Union[str, bytes, BinaryIO, None] = None,  # TODO: This should become a required input
     compressed=True,
     count: int = None,
     offset: bool = False,


### PR DESCRIPTION
Previously if no object was given to the load method it would give a criptic error message. This fixes that.
Previously there were two inputs for the given data. It was a little unobvious which input should be used and that there was a second one (usually I had to try twice to get it right). This squishes both inputs into one input. The second is currently kept for backwards compatabilty but I reccommend we remove it at some point and make the first required.
I have also added some more exceptions.
I have also renamed filename_or_buffer to filepath_or_buffer to better reflect what it is.