### PR TITLE
Fix cython

### DIFF
--- a/amulet_nbt/amulet_cy_nbt.pyx
+++ b/amulet_nbt/amulet_cy_nbt.pyx
@@ -182,7 +182,7 @@ cpdef bytes safe_gunzip(bytes data):
     return data
 
 cdef class _TAG_Value:
-    cdef public char tag_id
+    tag_id = None
 
     def copy(self):
         return self.__class__(self.value)
@@ -458,10 +458,8 @@ cdef inline primitive_conversion(obj):
 
 
 cdef class TAG_Byte(_Int):
+    tag_id = _ID_BYTE
     cdef readonly char value
-
-    def __cinit__(self):
-        self.tag_id = _ID_BYTE
 
     def __init__(self, value = 0):
         self.value = int(primitive_conversion(value))
@@ -473,10 +471,8 @@ cdef class TAG_Byte(_Int):
         write_byte(self.value, buffer)
 
 cdef class TAG_Short(_Int):
+    tag_id = _ID_SHORT
     cdef readonly short value
-
-    def __cinit__(self):
-        self.tag_id = _ID_SHORT
 
     def __init__(self, value = 0):
         self.value = int(primitive_conversion(value))
@@ -489,10 +485,8 @@ cdef class TAG_Short(_Int):
 
 
 cdef class TAG_Int(_Int):
+    tag_id = _ID_INT
     cdef readonly int value
-
-    def __cinit__(self):
-        self.tag_id = _ID_INT
 
     def __init__(self, value = 0):
         self.value = int(primitive_conversion(value))
@@ -505,10 +499,8 @@ cdef class TAG_Int(_Int):
 
 
 cdef class TAG_Long(_Int):
+    tag_id = _ID_LONG
     cdef readonly long long value
-
-    def __cinit__(self):
-        self.tag_id = _ID_LONG
 
     def __init__(self, value = 0):
         self.value = int(primitive_conversion(value))
@@ -521,10 +513,8 @@ cdef class TAG_Long(_Int):
 
 
 cdef class TAG_Float(_Float):
+    tag_id = _ID_FLOAT
     cdef readonly float value
-
-    def __cinit__(self):
-        self.tag_id = _ID_FLOAT
 
     def __init__(self, value = 0):
         self.value = float(primitive_conversion(value))
@@ -537,10 +527,8 @@ cdef class TAG_Float(_Float):
 
 
 cdef class TAG_Double(_Float):
+    tag_id = _ID_DOUBLE
     cdef readonly double value
-
-    def __cinit__(self):
-        self.tag_id = _ID_DOUBLE
 
     def __init__(self, value = 0):
         self.value = float(primitive_conversion(value))
@@ -688,10 +676,8 @@ cdef class _TAG_Array(_TAG_Value):
 BaseArrayType = _TAG_Array
 
 cdef class TAG_Byte_Array(_TAG_Array):
+    tag_id = _ID_BYTE_ARRAY
     big_endian_data_type = little_endian_data_type = numpy.dtype("int8")
-
-    def __cinit__(self):
-        self.tag_id = _ID_BYTE_ARRAY
 
     cpdef str _to_snbt(self):
         cdef int elem
@@ -709,11 +695,9 @@ cdef class TAG_Byte_Array(_TAG_Array):
         write_array(self.value, buffer, 1, little_endian)
 
 cdef class TAG_Int_Array(_TAG_Array):
+    tag_id = _ID_INT_ARRAY
     big_endian_data_type = numpy.dtype(">i4")
     little_endian_data_type = numpy.dtype("<i4")
-
-    def __cinit__(self):
-        self.tag_id = _ID_INT_ARRAY
 
     cpdef str _to_snbt(self):
         cdef int elem
@@ -731,11 +715,9 @@ cdef class TAG_Int_Array(_TAG_Array):
         write_array(self.value, buffer, 4, little_endian)
 
 cdef class TAG_Long_Array(_TAG_Array):
+    tag_id = _ID_LONG_ARRAY
     big_endian_data_type = numpy.dtype(">i8")
     little_endian_data_type = numpy.dtype("<i8")
-
-    def __cinit__(self):
-        self.tag_id = _ID_LONG_ARRAY
 
     cpdef str _to_snbt(self):
         cdef long long elem
@@ -760,10 +742,8 @@ def unescape(string: str):
     return string.replace('\\"', '"').replace("\\\\", "\\")
 
 cdef class TAG_String(_TAG_Value):
+    tag_id = _ID_STRING
     cdef readonly unicode value
-
-    def __cinit__(self):
-        self.tag_id = _ID_STRING
 
     def __init__(self, value = ""):
         self.value = str(value)
@@ -797,11 +777,9 @@ cdef class TAG_String(_TAG_Value):
 
 
 cdef class _TAG_List(_TAG_Value):
+    tag_id = _ID_LIST
     cdef public list value
     cdef public char list_data_type
-
-    def __cinit__(self):
-        self.tag_id = _ID_LIST
 
     def __init__(self, value = None, char list_data_type = 1):
         self.list_data_type = list_data_type
@@ -889,10 +867,8 @@ class TAG_List(_TAG_List, MutableSequence):
 
 
 cdef class _TAG_Compound(_TAG_Value):
+    tag_id = _ID_COMPOUND
     cdef public dict value
-
-    def __cinit__(self):
-        self.tag_id = _ID_COMPOUND
 
     def __init__(self, value = None):
         self.value = value or {}

--- a/amulet_nbt/amulet_cy_nbt.pyx
+++ b/amulet_nbt/amulet_cy_nbt.pyx
@@ -327,6 +327,18 @@ cdef class _Int(_TAG_Value):
     def __dir__(self):
         return dir(self.value)
 
+    def __ge__(self, other):
+        return self.value.__ge__(primitive_conversion(other))
+
+    def __gt__(self, other):
+        return self.value.__gt__(primitive_conversion(other))
+
+    def __le__(self, other):
+        return self.value.__le__(primitive_conversion(other))
+
+    def __lt__(self, other):
+        return self.value.__lt__(primitive_conversion(other))
+
 
 cdef class _Float(_TAG_Value):
     def __eq__(self, other):


### PR DESCRIPTION
Added greater than less that methods to int.
Made tag_id public in the class rather than just instances of the class. This allows `TAG_Byte.tag_id` which previously gave a property object