### PR TITLE
Cleanup

### DIFF
--- a/amulet_nbt/amulet_nbt_py/nbt_types/array.py
+++ b/amulet_nbt/amulet_nbt_py/nbt_types/array.py
@@ -1,15 +1,16 @@
 from __future__ import annotations
 
+from abc import ABC
 from typing import BinaryIO, ClassVar, Union, Iterable, Optional, Any
 import numpy as np
 
 from amulet_nbt.amulet_nbt_py.const import SNBTType
 from .int import TAG_Int
-from .value import TAG_Value
+from .value import BaseMutableTag, BaseTag
 from ..const import CommaSpace
 
 
-class ArrayTag(TAG_Value):
+class BaseArrayTag(BaseMutableTag, ABC):
     _value: np.ndarray
     _data_type: ClassVar = np.ndarray
     big_endian_data_type: ClassVar[np.dtype] = None
@@ -26,10 +27,6 @@ class ArrayTag(TAG_Value):
             None,
         ] = None,
     ):
-        if self.__class__ is ArrayTag:
-            raise TypeError(
-                "ArrayTag cannot be directly instanced. Use one of its subclasses."
-            )
         assert isinstance(
             self.big_endian_data_type, np.dtype
         ), f"big_endian_data_type not set for {self.__class__}"
@@ -42,7 +39,7 @@ class ArrayTag(TAG_Value):
         if value is None:
             return np.zeros((0,), self.big_endian_data_type)
         else:
-            if isinstance(value, TAG_Value):
+            if isinstance(value, BaseTag):
                 value = value.value
             return np.array(value, self.big_endian_data_type)
 
@@ -259,7 +256,7 @@ class ArrayTag(TAG_Value):
         return self._value.__bool__()
 
 
-class TAG_Byte_Array(ArrayTag):
+class TAG_Byte_Array(BaseArrayTag):
     big_endian_data_type = little_endian_data_type = np.dtype("int8")
     tag_id: ClassVar[int] = 7
 
@@ -267,7 +264,7 @@ class TAG_Byte_Array(ArrayTag):
         return f"[B;{'B, '.join(str(val) for val in self._value)}B]"
 
 
-class TAG_Int_Array(ArrayTag):
+class TAG_Int_Array(BaseArrayTag):
     big_endian_data_type = np.dtype(">i4")
     little_endian_data_type = np.dtype("<i4")
     tag_id: ClassVar[int] = 11
@@ -276,7 +273,7 @@ class TAG_Int_Array(ArrayTag):
         return f"[I;{CommaSpace.join(str(val) for val in self._value)}]"
 
 
-class TAG_Long_Array(ArrayTag):
+class TAG_Long_Array(BaseArrayTag):
     big_endian_data_type = np.dtype(">i8")
     little_endian_data_type = np.dtype("<i8")
     tag_id: ClassVar[int] = 12
@@ -285,4 +282,4 @@ class TAG_Long_Array(ArrayTag):
         return f"[L;{CommaSpace.join(str(val) for val in self._value)}]"
 
 
-BaseArrayType = ArrayTag
+BaseArrayType = BaseArrayTag

--- a/amulet_nbt/amulet_nbt_py/nbt_types/compound.py
+++ b/amulet_nbt/amulet_nbt_py/nbt_types/compound.py
@@ -14,7 +14,7 @@ from typing import (
 
 from amulet_nbt.amulet_nbt_py.const import SNBTType
 
-from .value import TAG_Value
+from .value import BaseTag, BaseMutableTag
 from ..const import TAG_END, NON_QUOTED_KEY, CommaSpace, CommaNewline
 from . import class_map
 
@@ -24,7 +24,7 @@ if TYPE_CHECKING:
 NBTDictType = Dict[str, "AnyNBT"]
 
 
-class TAG_Compound(TAG_Value):
+class TAG_Compound(BaseMutableTag):
     tag_id: ClassVar[int] = 10
     _value: NBTDictType
     _data_type: ClassVar = dict
@@ -36,7 +36,7 @@ class TAG_Compound(TAG_Value):
         if value is None:
             return self._data_type()
         else:
-            if isinstance(value, TAG_Value):
+            if isinstance(value, BaseTag):
                 value = value.value
             value = self._data_type(value)
             for key, value_ in value.items():
@@ -49,7 +49,7 @@ class TAG_Compound(TAG_Value):
             raise TypeError(
                 f"TAG_Compound key must be a string. Got {key.__class__.__name__}"
             )
-        if not isinstance(value, TAG_Value):
+        if not isinstance(value, BaseTag):
             raise TypeError(
                 f'Invalid type {value.__class__.__name__} for key "{key}" in TAG_Compound. Must be an NBT object.'
             )

--- a/amulet_nbt/amulet_nbt_py/nbt_types/float.py
+++ b/amulet_nbt/amulet_nbt_py/nbt_types/float.py
@@ -5,19 +5,12 @@ from typing import ClassVar, Union
 import numpy as np
 
 from ..const import SNBTType
-from .numeric import NumericTAG
+from .numeric import BaseNumericTag
 
 
-class BaseFloatTAG(NumericTAG):
+class BaseFloatTag(BaseNumericTag):
     _value: np.floating
     _data_type: ClassVar = np.floating
-
-    def __init__(self, value: Union[int, float, np.number, NumericTAG, None] = None):
-        if self.__class__ is BaseFloatTAG:
-            raise TypeError(
-                "BaseFloatTAG cannot be directly instanced. Use one of its subclasses."
-            )
-        super().__init__(value)
 
     @property
     def value(self) -> float:
@@ -27,7 +20,7 @@ class BaseFloatTAG(NumericTAG):
         return self.fstring.format(f"{self._value:.20f}".rstrip("0"))
 
 
-class TAG_Float(BaseFloatTAG):
+class TAG_Float(BaseFloatTag):
     tag_id: ClassVar[int] = 5
     _value: np.float32
     _data_type: ClassVar = np.float32
@@ -36,7 +29,7 @@ class TAG_Float(BaseFloatTAG):
     fstring = "{}f"
 
 
-class TAG_Double(BaseFloatTAG):
+class TAG_Double(BaseFloatTag):
     tag_id: ClassVar[int] = 6
     _value: np.float64
     _data_type: ClassVar = np.float64

--- a/amulet_nbt/amulet_nbt_py/nbt_types/int.py
+++ b/amulet_nbt/amulet_nbt_py/nbt_types/int.py
@@ -1,22 +1,16 @@
 from __future__ import annotations
 
+from abc import ABC
 from struct import Struct
 from typing import ClassVar, Union
 import numpy as np
 
-from .numeric import NumericTAG
+from .numeric import BaseNumericTag
 
 
-class BaseIntegerTAG(NumericTAG):
+class BaseIntegerTag(BaseNumericTag, ABC):
     _value: np.signedinteger
     _data_type: ClassVar = np.signedinteger
-
-    def __init__(self, value: Union[int, float, np.number, NumericTAG, None] = None):
-        if self.__class__ is BaseIntegerTAG:
-            raise TypeError(
-                "BaseIntegerTAG cannot be directly instanced. Use one of its subclasses."
-            )
-        super().__init__(value)
 
     @property
     def value(self) -> int:
@@ -71,7 +65,7 @@ class BaseIntegerTAG(NumericTAG):
         return self._value.__invert__()
 
 
-class TAG_Byte(BaseIntegerTAG):
+class TAG_Byte(BaseIntegerTag):
     tag_id: ClassVar[int] = 1
     _value: np.int8
     _data_type: ClassVar = np.int8
@@ -80,7 +74,7 @@ class TAG_Byte(BaseIntegerTAG):
     fstring = "{}b"
 
 
-class TAG_Short(BaseIntegerTAG):
+class TAG_Short(BaseIntegerTag):
     tag_id: ClassVar[int] = 2
     _value: np.int16
     _data_type: ClassVar = np.int16
@@ -89,7 +83,7 @@ class TAG_Short(BaseIntegerTAG):
     fstring = "{}s"
 
 
-class TAG_Int(BaseIntegerTAG):
+class TAG_Int(BaseIntegerTag):
     tag_id: ClassVar[int] = 3
     _value: np.int32
     _data_type: ClassVar = np.int32
@@ -98,7 +92,7 @@ class TAG_Int(BaseIntegerTAG):
     fstring = "{}"
 
 
-class TAG_Long(BaseIntegerTAG):
+class TAG_Long(BaseIntegerTag):
     tag_id: ClassVar[int] = 4
     _value: np.int64
     _data_type: ClassVar = np.int64

--- a/amulet_nbt/amulet_nbt_py/nbt_types/list.py
+++ b/amulet_nbt/amulet_nbt_py/nbt_types/list.py
@@ -17,7 +17,7 @@ import numpy as np
 
 from amulet_nbt.amulet_nbt_py.const import SNBTType
 
-from .value import TAG_Value
+from .value import BaseTag, BaseMutableTag
 from . import class_map
 from ..const import TAG_BYTE, CommaSpace, CommaNewline
 from .int import TAG_Int
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 NBTListType = List["AnyNBT"]
 
 
-class TAG_List(TAG_Value):
+class TAG_List(BaseMutableTag):
     tag_id: ClassVar[int] = 9
     _value: NBTListType
     _data_type: ClassVar = list
@@ -44,7 +44,7 @@ class TAG_List(TAG_Value):
     def _sanitise_value(self, value: Optional[Any]) -> Any:
         self._value = self._data_type()
         if value:
-            if isinstance(value, TAG_Value):
+            if isinstance(value, BaseTag):
                 value = value.value
             value = self._data_type(value)
             self._check_tag_iterable(value)
@@ -52,14 +52,14 @@ class TAG_List(TAG_Value):
             value = self._value
         return value
 
-    def _check_tag(self, value: TAG_Value, fix_if_empty=True):
+    def _check_tag(self, value: BaseTag, fix_if_empty=True):
         """Check the format of value is correct.
 
         :param value: The value to check
         :param fix_if_empty: If true and the internal list is empty the internal data type will be set to that of value.
         :return:
         """
-        if not isinstance(value, TAG_Value):
+        if not isinstance(value, BaseTag):
             raise TypeError(
                 f"Invalid type {value.__class__.__name__} for TAG_List. Must be an NBT object."
             )
@@ -70,7 +70,7 @@ class TAG_List(TAG_Value):
                 f"Invalid type {value.__class__.__name__} for TAG_List({class_map.TAG_CLASSES[self.list_data_type].__name__})"
             )
 
-    def _check_tag_iterable(self, value: Sequence[TAG_Value]):
+    def _check_tag_iterable(self, value: Sequence[BaseTag]):
         if value:
             self._check_tag(value[0])
             for tag in value[1:]:

--- a/amulet_nbt/amulet_nbt_py/nbt_types/numeric.py
+++ b/amulet_nbt/amulet_nbt_py/nbt_types/numeric.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from abc import ABC
 from typing import (
     ClassVar,
     BinaryIO,
@@ -10,21 +11,19 @@ import numpy as np
 
 from amulet_nbt.amulet_nbt_py.const import SNBTType
 
-from .value import TAG_Value
+from .value import BaseImmutableTag
 
 
-class NumericTAG(TAG_Value):
+class BaseNumericTag(BaseImmutableTag, ABC):
     _value: np.number
     _data_type: ClassVar = np.number
     tag_format_be: ClassVar[Struct] = None
     tag_format_le: ClassVar[Struct] = None
     fstring: str = None
 
-    def __init__(self, value: Union[int, float, np.number, NumericTAG, None] = None):
-        if self.__class__ is NumericTAG:
-            raise TypeError(
-                "NumericTAG cannot be directly instanced. Use one of its subclasses."
-            )
+    def __init__(
+        self, value: Union[int, float, np.number, BaseNumericTag, None] = None
+    ):
         assert isinstance(
             self.tag_format_be, Struct
         ), f"tag_format_be not set for {self.__class__}"

--- a/amulet_nbt/amulet_nbt_py/nbt_types/string.py
+++ b/amulet_nbt/amulet_nbt_py/nbt_types/string.py
@@ -3,10 +3,10 @@ from __future__ import annotations
 from typing import ClassVar, BinaryIO
 
 from amulet_nbt.amulet_nbt_py.const import SNBTType
-from .value import TAG_Value
+from .value import BaseImmutableTag
 
 
-class TAG_String(TAG_Value):
+class TAG_String(BaseImmutableTag):
     tag_id: ClassVar[int] = 8
     _value: str
     _data_type: ClassVar = str

--- a/amulet_nbt/amulet_nbt_py/nbt_types/value.py
+++ b/amulet_nbt/amulet_nbt_py/nbt_types/value.py
@@ -21,7 +21,7 @@ _string_len_fmt_be = Struct(">H")
 _string_len_fmt_le = Struct("<H")
 
 
-class TAG_Value(ABC):
+class BaseTag(ABC):
     _value: Any
     _data_type: ClassVar = None
 
@@ -33,8 +33,6 @@ class TAG_Value(ABC):
             raise ValueError(
                 f"value of {self.__class__.__name__} must be of type {self._data_type}"
             )
-        if isinstance(value, TAG_Value):
-            raise ValueError("value must not be a instance of TAG_Value")
         self._value = value
 
     @property
@@ -47,7 +45,7 @@ class TAG_Value(ABC):
         if value is None:
             return self._data_type()
         else:
-            if isinstance(value, TAG_Value):
+            if isinstance(value, BaseTag):
                 value = value.value
             return self._data_type(value)
 
@@ -150,15 +148,12 @@ class TAG_Value(ABC):
     def __lt__(self, other):
         return self._value.__lt__(self.get_primitive(other))
 
-    def __hash__(self):
-        return self._value.__hash__()
-
     @staticmethod
     def get_primitive(obj):
         """Get the primitive object of the data.
-        If obj is an instance of TAG_Value then obj.value is used.
+        If obj is an instance of BaseTag then obj.value is used.
         Else obj is returned."""
-        return obj.value if isinstance(obj, TAG_Value) else obj
+        return obj.value if isinstance(obj, BaseTag) else obj
 
     def __deepcopy__(self, memo=None):
         return self.__class__(deepcopy(self._value, memo=memo))
@@ -167,4 +162,13 @@ class TAG_Value(ABC):
         return self.__class__(copy(self._value))
 
 
-BaseValueType = TAG_Value
+class BaseImmutableTag(BaseTag, ABC):
+    def __hash__(self):
+        return self._value.__hash__()
+
+
+class BaseMutableTag(BaseTag, ABC):
+    pass
+
+
+BaseValueType = BaseTag


### PR DESCRIPTION
This adds mutable and immutable base classes and standardises the base class naming scheme a bit better.
I was going to try adding a hash method to the immutable base class. I have done so in python and it works as intended but once added to the cython version it causes equality checks to break and the actual `__eq__` method is not actually called.
Any ideas @Podshot?