### PR TITLE
Implement hashing in the old NBT library

### DIFF
--- a/amulet_nbt/amulet_cy_nbt.pyx
+++ b/amulet_nbt/amulet_cy_nbt.pyx
@@ -186,6 +186,9 @@ cpdef bytes safe_gunzip(bytes data):
 cdef class _TAG_Value:
     tag_id = None
 
+    def __hash__(self):
+        return hash((self.tag_id, self.value))
+
     def copy(self):
         return self.__class__(self.value)
 

--- a/amulet_nbt/amulet_nbt_py/nbt_types/value.py
+++ b/amulet_nbt/amulet_nbt_py/nbt_types/value.py
@@ -151,7 +151,7 @@ class TAG_Value(ABC):
         return self._value.__lt__(self.get_primitive(other))
 
     def __hash__(self):
-        return self._value.__hash__()
+        return hash((self.tag_id, self.value))
 
     @staticmethod
     def get_primitive(obj):


### PR DESCRIPTION
With the NBT rewrite taking longer than expected this adds in hashing support to the old NBT library.
This isn't pretty but will work until the rewrite is finished.
