### PR TITLE
Removed closing of the `read`able object

### DIFF
--- a/amulet_nbt/amulet_cy_nbt.pyx
+++ b/amulet_nbt/amulet_cy_nbt.pyx
@@ -1070,12 +1070,6 @@ def load(
             data_in = filepath_or_buffer.read()
             if not isinstance(data_in, bytes):
                 raise NBTLoadError(f"buffer.read() must return a bytes object. Got {type(data_in)} instead.")
-            if hasattr(filepath_or_buffer, "close"):
-                filepath_or_buffer.close()
-            elif hasattr(filepath_or_buffer, "open"):
-                print(
-                    "[Warning]: Input buffer didn't have close() function. Memory leak may occur!"
-                )
         else:
             raise NBTLoadError("buffer did not have a read method.")
 


### PR DESCRIPTION
If an object was given to this function that has a read method it should be the job of the calling code to close the object.
There may be cases where the calling code wants to continue using the file handler so forcefully closing it here is not a good idea.