### PR TITLE
Added memoryview support in load functions

### DIFF
--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -29,6 +29,6 @@ jobs:
       shell: bash
       run: |
         python -m pip install --upgrade pip
-        pip install -e .
+        pip install -e .[dev]
     - name: Test with unittest
       run: python -m unittest discover -v -s tests

--- a/amulet_nbt/_load_nbt.pyi
+++ b/amulet_nbt/_load_nbt.pyi
@@ -7,7 +7,7 @@ class ReadContext:
     offset: int
 
 def load(
-    filepath_or_buffer: Union[str, bytes, BinaryIO, None],
+    filepath_or_buffer: Union[str, bytes, BinaryIO, memoryview, None],
     *,
     compressed: bool = True,
     little_endian: bool = False,
@@ -15,7 +15,7 @@ def load(
     string_decoder: DecoderType = decode_modified_utf8,
 ) -> NamedTag: ...
 def load_many(
-    filepath_or_buffer: Union[str, bytes, BinaryIO, None],
+    filepath_or_buffer: Union[str, bytes, BinaryIO, memoryview, None],
     *,
     count: int = 1,
     compressed: bool = True,

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,6 +36,7 @@ docs =
 dev =
     black>=22.3
     pre_commit>=1.11.1
+    cython >= 3.0.0a9
 
 
 [options.entry_points]


### PR DESCRIPTION
The load functions accept memoryviews as inputs.
This won't give any speed improvements because it is converted to bytes internally.
More rewriting could be done to support this better.