### PR TITLE
Fixed incorrect return type

### DIFF
--- a/amulet_nbt/_list.pyx
+++ b/amulet_nbt/_list.pyx
@@ -150,7 +150,7 @@ cdef class CyListTag(AbstractBaseMutableTag):
     def __len__(CyListTag self) -> int:
         return self.value_.__len__()
 
-    def __getitem__(CyListTag self, index: int) -> AnyNBT:
+    def __getitem__(CyListTag self, index) -> AnyNBT:
         return self.value_[index]
 
     def __setitem__(CyListTag self, index, value):

--- a/amulet_nbt/_load_nbt.pyx
+++ b/amulet_nbt/_load_nbt.pyx
@@ -203,7 +203,8 @@ def load(
             string_decoder=string_decoder
         )
 
-    if read_context is None:
-        return result
-    else:
+    if offset:
+        # depreciated
         return result, read_context.offset
+    else:
+        return result

--- a/template/src/_list.pyx
+++ b/template/src/_list.pyx
@@ -131,7 +131,7 @@ cdef class CyListTag(AbstractBaseMutableTag):
     def __len__(CyListTag self) -> int:
         return self.value_.__len__()
 
-    def __getitem__(CyListTag self, index: int) -> AnyNBT:
+    def __getitem__(CyListTag self, index) -> AnyNBT:
         return self.value_[index]
 
     def __setitem__(CyListTag self, index, value):


### PR DESCRIPTION
The multiple return is the legacy behaviour that should only be exposed when using the deprecated offset input.

Fixes Amulet-Team/Amulet-Map-Editor#762