### PR TITLE
Added import_array after cimporting numpy

### DIFF
--- a/amulet_nbt/_array.pxd
+++ b/amulet_nbt/_array.pxd
@@ -1,4 +1,6 @@
+import numpy
 cimport numpy
+numpy.import_array()
 from ._value cimport AbstractBaseMutableTag
 from ._util cimport BufferContext
 

--- a/amulet_nbt/_array.pyx
+++ b/amulet_nbt/_array.pyx
@@ -3,6 +3,7 @@
 
 import numpy
 cimport numpy
+numpy.import_array()
 from io import BytesIO
 from copy import deepcopy
 import warnings

--- a/template/src/_array.pyx
+++ b/template/src/_array.pyx
@@ -3,6 +3,7 @@
 
 import numpy
 cimport numpy
+numpy.import_array()
 from io import BytesIO
 from copy import deepcopy
 import warnings


### PR DESCRIPTION
This is required otherwise it errors on some platforms.

Fixes Amulet-Team/Amulet-Map-Editor#822