### PR TITLE
Fixed unsigned char bug

### DIFF
--- a/amulet_nbt/_int.pxd
+++ b/amulet_nbt/_int.pxd
@@ -7,8 +7,8 @@ cdef class AbstractBaseIntTag(AbstractBaseNumericTag):
 cdef ByteTag read_byte_tag(BufferContext buffer, bint little_endian)
 
 cdef class ByteTag(AbstractBaseIntTag):
-    cdef char value_
-    cdef char _sanitise_value(self, value)
+    cdef signed char value_
+    cdef signed char _sanitise_value(self, value)
 
 cdef ShortTag read_short_tag(BufferContext buffer, bint little_endian)
 

--- a/amulet_nbt/_int.pyx
+++ b/amulet_nbt/_int.pyx
@@ -266,7 +266,7 @@ cdef class ByteTag(AbstractBaseIntTag):
             warnings.warn(f"__invert__ is depreciated on ByteTag and will be removed in the future. Please use .py_int to achieve the same behaviour.", DeprecationWarning)
             return ~self.value_
 
-    cdef char _sanitise_value(ByteTag self, value):
+    cdef signed char _sanitise_value(ByteTag self, value):
         return (value & 0x7F) - (value & 0x80)
 
     cdef str _to_snbt(ByteTag self):

--- a/template/src/_int.pyx
+++ b/template/src/_int.pyx
@@ -63,7 +63,7 @@ cdef class ByteTag(AbstractBaseIntTag):
 
 {{include("AbstractBaseIntTag.pyx", cls_name="ByteTag")}}
 
-    cdef char _sanitise_value(ByteTag self, value):
+    cdef signed char _sanitise_value(ByteTag self, value):
         return (value & 0x7F) - (value & 0x80)
 
     cdef str _to_snbt(ByteTag self):


### PR DESCRIPTION
On some compilers char is unsigned by default.
This ensures it is signed.

Fixes Amulet-Team/Amulet-Core#233