### PR TITLE
Use binary NBT when pickling

### DIFF
--- a/src/amulet_nbt/_nbt_encoding/_binary/_cpp/read_nbt.cpp
+++ b/src/amulet_nbt/_nbt_encoding/_binary/_cpp/read_nbt.cpp
@@ -166,6 +166,6 @@ std::pair<std::string, TagNode> read_named_tag(const std::string& raw, std::endi
 
 
 std::pair<std::string, TagNode> read_named_tag(const std::string& raw, std::endian endianness, StringDecode stringDecode){
-    size_t offset;
+    size_t offset = 0;
     return read_named_tag(raw, endianness, stringDecode, offset);
 }

--- a/src/amulet_nbt/_tag/compound.pyx.tp
+++ b/src/amulet_nbt/_tag/compound.pyx.tp
@@ -7,6 +7,7 @@ from template import include
 # distutils: language = c++
 # distutils: extra_compile_args = CPPCARGS
 # cython: c_string_type=str, c_string_encoding=utf8
+# distutils: sources = [src/amulet_nbt/_string_encoding/_cpp/utf8.cpp, src/amulet_nbt/_nbt_encoding/_binary/_cpp/read_nbt.cpp]
 
 from __future__ import annotations
 
@@ -15,11 +16,14 @@ from typing import Any, overload, Type, TypeVar
 
 from libcpp.string cimport string
 from libcpp cimport bool
+from libcpp.pair cimport pair
 from libcpp.memory cimport make_shared
 from cython.operator cimport dereference, postincrement
 import amulet_nbt
 from amulet_nbt._libcpp.endian cimport endian
 from amulet_nbt._string_encoding._cpp cimport CStringEncode
+from amulet_nbt._string_encoding._cpp.utf8 cimport utf8_escape_to_utf8, utf8_to_utf8_escape
+from amulet_nbt._nbt_encoding._binary._cpp cimport read_named_tag
 from amulet_nbt._nbt_encoding._binary cimport write_named_tag
 from amulet_nbt._nbt_encoding._string cimport write_compound_snbt
 
@@ -132,6 +136,11 @@ f"""    {"el"*(index!=1)}if index == {index}:
 _TagT = TypeVar("_TagT", bound=AbstractBaseTag)
 
 
+def _unpickle(string data) -> CompoundTag:
+    cdef pair[string, TagNode] named_tag = read_named_tag(data, endian.big, utf8_to_utf8_escape)
+    return CompoundTag.wrap(get[CCompoundTagPtr](named_tag.second))
+
+
 cdef class CompoundTag(AbstractBaseMutableTag):
     """A Python wrapper around a C++ unordered map.
 
@@ -190,7 +199,8 @@ cdef class CompoundTag(AbstractBaseMutableTag):
         return str(dict(self))
 
     def __reduce__(self):
-        return CompoundTag, (dict(self),)
+        cdef bytes nbt = self.write_nbt(b"", endian.big, utf8_escape_to_utf8)
+        return _unpickle, (nbt,)
 
     def __copy__(self) -> CompoundTag:
         return CompoundTag.wrap(

--- a/src/amulet_nbt/_tag/list.pyx
+++ b/src/amulet_nbt/_tag/list.pyx
@@ -5,12 +5,14 @@
 # distutils: language = c++
 # distutils: extra_compile_args = CPPCARGS
 # cython: c_string_type=str, c_string_encoding=utf8
+# distutils: sources = [src/amulet_nbt/_string_encoding/_cpp/utf8.cpp, src/amulet_nbt/_nbt_encoding/_binary/_cpp/read_nbt.cpp]
 
 from typing import Any, Type
 from collections.abc import Iterable
 
 from libc.math cimport ceil
 from libcpp cimport bool
+from libcpp.pair cimport pair
 from libcpp.memory cimport make_shared
 from libcpp.string cimport string
 from cython.operator cimport dereference
@@ -18,6 +20,8 @@ import amulet_nbt
 from amulet_nbt._libcpp.variant cimport get, monostate
 from amulet_nbt._libcpp.endian cimport endian
 from amulet_nbt._string_encoding._cpp cimport CStringEncode
+from amulet_nbt._string_encoding._cpp.utf8 cimport utf8_escape_to_utf8, utf8_to_utf8_escape
+from amulet_nbt._nbt_encoding._binary._cpp cimport read_named_tag
 from amulet_nbt._nbt_encoding._binary cimport write_named_tag
 from amulet_nbt._nbt_encoding._string cimport write_list_snbt
 
@@ -2487,6 +2491,11 @@ cdef inline void ListTag_append(CListTagPtr cpp, AbstractBaseTag value):
         raise TypeError(f"Unsupported type {type(value)}")
 
 
+def _unpickle(string data) -> ListTag:
+    cdef pair[string, TagNode] named_tag = read_named_tag(data, endian.big, utf8_to_utf8_escape)
+    return ListTag.wrap(get[CListTagPtr](named_tag.second))
+
+
 cdef class ListTag(AbstractBaseMutableTag):
     """A Python wrapper around a C++ vector.
 
@@ -2584,7 +2593,8 @@ cdef class ListTag(AbstractBaseMutableTag):
         return str(list(self))
 
     def __reduce__(self):
-        return ListTag, (list(self), self.element_tag_id)
+        cdef bytes nbt = self.write_nbt(b"", endian.big, utf8_escape_to_utf8)
+        return _unpickle, (nbt,)
 
     def __copy__(self) -> ListTag:
         return ListTag.wrap(

--- a/src/amulet_nbt/_tag/list.pyx.tp
+++ b/src/amulet_nbt/_tag/list.pyx.tp
@@ -7,12 +7,14 @@ from template import include
 # distutils: language = c++
 # distutils: extra_compile_args = CPPCARGS
 # cython: c_string_type=str, c_string_encoding=utf8
+# distutils: sources = [src/amulet_nbt/_string_encoding/_cpp/utf8.cpp, src/amulet_nbt/_nbt_encoding/_binary/_cpp/read_nbt.cpp]
 
 from typing import Any, Type
 from collections.abc import Iterable
 
 from libc.math cimport ceil
 from libcpp cimport bool
+from libcpp.pair cimport pair
 from libcpp.memory cimport make_shared
 from libcpp.string cimport string
 from cython.operator cimport dereference
@@ -20,6 +22,8 @@ import amulet_nbt
 from amulet_nbt._libcpp.variant cimport get, monostate
 from amulet_nbt._libcpp.endian cimport endian
 from amulet_nbt._string_encoding._cpp cimport CStringEncode
+from amulet_nbt._string_encoding._cpp.utf8 cimport utf8_escape_to_utf8, utf8_to_utf8_escape
+from amulet_nbt._nbt_encoding._binary._cpp cimport read_named_tag
 from amulet_nbt._nbt_encoding._binary cimport write_named_tag
 from amulet_nbt._nbt_encoding._string cimport write_list_snbt
 
@@ -486,6 +490,11 @@ cdef inline void ListTag_append(CListTagPtr cpp, AbstractBaseTag value):
         raise TypeError(f"Unsupported type {{'{'}}type(value){{'}'}}")
 
 
+def _unpickle(string data) -> ListTag:
+    cdef pair[string, TagNode] named_tag = read_named_tag(data, endian.big, utf8_to_utf8_escape)
+    return ListTag.wrap(get[CListTagPtr](named_tag.second))
+
+
 cdef class ListTag(AbstractBaseMutableTag):
     """A Python wrapper around a C++ vector.
 
@@ -553,7 +562,8 @@ cdef class ListTag(AbstractBaseMutableTag):
         return str(list(self))
 
     def __reduce__(self):
-        return ListTag, (list(self), self.element_tag_id)
+        cdef bytes nbt = self.write_nbt(b"", endian.big, utf8_escape_to_utf8)
+        return _unpickle, (nbt,)
 
     def __copy__(self) -> ListTag:
         return ListTag.wrap(

--- a/src/amulet_nbt/_tag/named_tag.pxd
+++ b/src/amulet_nbt/_tag/named_tag.pxd
@@ -9,3 +9,5 @@ cdef class NamedTag(AbstractBase):
     cdef string tag_name
     cdef TagNode tag_node
     cdef string write_nbt(self, endian endianness, CStringEncode string_encode)
+    @staticmethod
+    cdef NamedTag wrap(string name, TagNode node)

--- a/src/amulet_nbt/_tag/named_tag.pyx
+++ b/src/amulet_nbt/_tag/named_tag.pyx
@@ -5,16 +5,21 @@
 # distutils: language = c++
 # distutils: extra_compile_args = CPPCARGS
 # cython: c_string_type=str, c_string_encoding=utf8
+# distutils: sources = [src/amulet_nbt/_string_encoding/_cpp/utf8.cpp, src/amulet_nbt/_nbt_encoding/_binary/_cpp/read_nbt.cpp]
 
+from typing import Any
 import copy
 import gzip
 from libcpp.string cimport string
 from libcpp cimport bool
+from libcpp.pair cimport pair
 import amulet_nbt
 from amulet_nbt._libcpp.endian cimport endian
 from amulet_nbt._string_encoding cimport StringEncoding
 from amulet_nbt._string_encoding import mutf8_encoding
 from amulet_nbt._string_encoding._cpp cimport CStringEncode
+from amulet_nbt._string_encoding._cpp.utf8 cimport utf8_escape_to_utf8, utf8_to_utf8_escape
+from amulet_nbt._nbt_encoding._binary._cpp cimport read_named_tag
 from amulet_nbt._nbt_encoding._binary cimport write_named_tag
 from amulet_nbt._nbt_encoding._binary.encoding_preset cimport EncodingPreset
 from amulet_nbt._nbt_encoding._string cimport write_node_snbt
@@ -28,12 +33,24 @@ from .compound cimport wrap_node, CompoundTag
 from .array cimport ByteArrayTag, IntArrayTag, LongArrayTag
 
 
+def _unpickle(string data):
+    cdef pair[string, TagNode] named_tag = read_named_tag(data, endian.big, utf8_to_utf8_escape)
+    return NamedTag.wrap(named_tag.first, named_tag.second)
+
+
 cdef class NamedTag(AbstractBase):
     def __init__(self, AbstractBaseTag tag: amulet_nbt.AbstractBaseTag = None, string name: str | bytes = b"") -> None:
         if tag is None:
             tag = CompoundTag()
         self.tag_node = tag.to_node()
         self.tag_name = name
+
+    @staticmethod
+    cdef NamedTag wrap(string name, TagNode node):
+        cdef NamedTag self = NamedTag.__new__(NamedTag)
+        self.tag_name = name
+        self.tag_node = node
+        return self
 
     @property
     def tag(self) -> AbstractBaseTag:
@@ -162,7 +179,8 @@ cdef class NamedTag(AbstractBase):
         return f'NamedTag({self.tag!r}, "{self.name}")'
 
     def __reduce__(self):
-        return NamedTag, (self.tag, self.name)
+        cdef bytes nbt = self.write_nbt(endian.big, utf8_escape_to_utf8)
+        return _unpickle, (nbt,)
 
     def __copy__(self) -> NamedTag:
         return NamedTag(self.tag, self.name)

--- a/src/amulet_nbt/_tag/named_tag.pyx.tp
+++ b/src/amulet_nbt/_tag/named_tag.pyx.tp
@@ -7,16 +7,21 @@ from template import include
 # distutils: language = c++
 # distutils: extra_compile_args = CPPCARGS
 # cython: c_string_type=str, c_string_encoding=utf8
+# distutils: sources = [src/amulet_nbt/_string_encoding/_cpp/utf8.cpp, src/amulet_nbt/_nbt_encoding/_binary/_cpp/read_nbt.cpp]
 
+from typing import Any
 import copy
 import gzip
 from libcpp.string cimport string
 from libcpp cimport bool
+from libcpp.pair cimport pair
 import amulet_nbt
 from amulet_nbt._libcpp.endian cimport endian
 from amulet_nbt._string_encoding cimport StringEncoding
 from amulet_nbt._string_encoding import mutf8_encoding
 from amulet_nbt._string_encoding._cpp cimport CStringEncode
+from amulet_nbt._string_encoding._cpp.utf8 cimport utf8_escape_to_utf8, utf8_to_utf8_escape
+from amulet_nbt._nbt_encoding._binary._cpp cimport read_named_tag
 from amulet_nbt._nbt_encoding._binary cimport write_named_tag
 from amulet_nbt._nbt_encoding._binary.encoding_preset cimport EncodingPreset
 from amulet_nbt._nbt_encoding._string cimport write_node_snbt
@@ -30,12 +35,24 @@ from .compound cimport wrap_node, CompoundTag
 from .array cimport ByteArrayTag, IntArrayTag, LongArrayTag
 
 
+def _unpickle(string data):
+    cdef pair[string, TagNode] named_tag = read_named_tag(data, endian.big, utf8_to_utf8_escape)
+    return NamedTag.wrap(named_tag.first, named_tag.second)
+
+
 cdef class NamedTag(AbstractBase):
     def __init__(self, AbstractBaseTag tag: amulet_nbt.AbstractBaseTag = None, string name: str | bytes = b"") -> None:
         if tag is None:
             tag = CompoundTag()
         self.tag_node = tag.to_node()
         self.tag_name = name
+
+    @staticmethod
+    cdef NamedTag wrap(string name, TagNode node):
+        cdef NamedTag self = NamedTag.__new__(NamedTag)
+        self.tag_name = name
+        self.tag_node = node
+        return self
 
     @property
     def tag(self) -> AbstractBaseTag:
@@ -164,7 +181,8 @@ cdef class NamedTag(AbstractBase):
         return f'NamedTag({self.tag!r}, "{self.name}")'
 
     def __reduce__(self):
-        return NamedTag, (self.tag, self.name)
+        cdef bytes nbt = self.write_nbt(endian.big, utf8_escape_to_utf8)
+        return _unpickle, (nbt,)
 
     def __copy__(self) -> NamedTag:
         return NamedTag(self.tag, self.name)


### PR DESCRIPTION
Serialising container classes to binary NBT when pickling is faster than recursing in python. This could also allow some amount of parallelisation.