### PR TITLE
Refactored encoding classes

### DIFF
--- a/src/amulet_nbt/cpp/nbt_encoding/binary/write_binary.cpp
+++ b/src/amulet_nbt/cpp/nbt_encoding/binary/write_binary.cpp
@@ -41,7 +41,7 @@ inline void write_string(AmuletNBT::BinaryWriter& writer, const std::string& val
         throw std::overflow_error("String of length " + std::to_string(encoded_string.size()) + " is too long.");
     }
     writer.writeNumeric<std::uint16_t>(static_cast<std::uint16_t>(encoded_string.size()));
-    writer.writeString(encoded_string);
+    writer.writeBytes(encoded_string);
 }
 
 template <

--- a/src/amulet_nbt/include/amulet_nbt/io/binary_reader.hpp
+++ b/src/amulet_nbt/include/amulet_nbt/io/binary_reader.hpp
@@ -15,7 +15,7 @@ namespace AmuletNBT {
 
 
     class BinaryReader {
-    private:
+    protected:
         const std::string& data;
         size_t& position;
         std::endian endianness;
@@ -69,6 +69,7 @@ namespace AmuletNBT {
             return value;
         }
 
+        // Read length bytes, decode and return.
         std::string readString(size_t length) {
             // Ensure the buffer is long enough
             if (position + length > data.size()) {
@@ -80,10 +81,12 @@ namespace AmuletNBT {
             return string_decode(value);
         }
 
+        // Get the current read position.
         size_t getPosition(){
             return position;
         }
 
+        // Is there more unread data.
         bool has_more_data(){
             return position < data.size();
         }

--- a/src/amulet_nbt/include/amulet_nbt/io/binary_writer.hpp
+++ b/src/amulet_nbt/include/amulet_nbt/io/binary_writer.hpp
@@ -14,7 +14,7 @@ namespace AmuletNBT {
 
 
     class BinaryWriter {
-    private:
+    protected:
         std::string data;
         std::endian endianness;
         StringEncode string_encode;
@@ -42,15 +42,17 @@ namespace AmuletNBT {
             }
         }
 
+        // Encode and return a string.
         std::string encodeString(const std::string& value) {
             return string_encode(value);
         }
 
-        void writeString(const std::string& value) {
+        // Write a string without encoding or prefixed size.
+        void writeBytes(const std::string& value) {
             data.append(value);
         }
 
-        std::string getBuffer(){
+        const std::string& getBuffer(){
             return data;
         }
     };


### PR DESCRIPTION
Data is now protected to allow extensions of the classes. Renamed writeString to writeBytes. No encoding is done in this function. Added docstrings.
Get buffer now returns a reference rather than a copy.