### PR TITLE
Revert package finding

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ platforms = any
 [options]
 package_dir=
     =src
-packages = find:
+packages = find_namespace:
 zip_safe = False
 python_requires = ~=3.11
 install_requires =


### PR DESCRIPTION
The package does not have an __init__ that the build system recognises.
With `find` none of the extra files are collected.