### PR TITLE
Improve build tooling

### DIFF
--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -54,9 +54,13 @@ jobs:
       run: |
         twine upload lib/Amulet-Compiler-Version/dist/* --skip-existing
 
-    - name: Build Amulet-NBT
+    - name: Build Amulet-NBT Source Distribution
       run: |
-        python -m build -C=AMULET_FREEZE_COMPILER=1 .
+        python -m build --sdist .
+
+    - name: Build Amulet-NBT Compiled Distribution
+      run: |
+        python -m build -C=AMULET_FREEZE_COMPILER=1 --wheel .
 
     - name: Publish Amulet-NBT
       env:

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -8,26 +8,57 @@ on:
     types: [published]
 
 jobs:
-  deploy-wheel:
-    runs-on: ${{ matrix.os }}
+  deploy:
     strategy:
+      fail-fast: false
       matrix:
-        python-version: ['3.11']
-        os: [ubuntu-latest]
+        python-version: ['3.11', '3.12', '3.13']
+        os: [macos-latest, windows-latest]
+
+    runs-on: ${{ matrix.os }}
+    defaults:
+      run:
+        shell: bash
+
     steps:
-    - uses: actions/checkout@v4
+    - name: Clone Amulet-NBT.
+      uses: actions/checkout@v4
+
     - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install build twine
-    - name: Build and publish
+
+    - name: Clone Amulet-Compiler-Version
+      uses: actions/checkout@v4
+      with:
+        repository: 'Amulet-Team/Amulet-Compiler-Version'
+        ref: '1.0'
+        path: 'lib/Amulet-Compiler-Version'
+
+    - name: Build Amulet-Compiler-Version
+      run: |
+        python -m build lib/Amulet-Compiler-Version
+
+    - name: Publish Amulet-Compiler-Version
+      env:
+        TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
+        TWINE_PASSWORD: ${{ secrets.AMULET_COMPILER_VERSION_PYPI_PASSWORD }}
+      run: |
+        twine upload lib/Amulet-Compiler-Version/dist/* --skip-existing
+
+    - name: Build Amulet-NBT
+      run: |
+        python -m build -C=AMULET_FREEZE_COMPILER=1 .
+
+    - name: Publish Amulet-NBT
       env:
         TWINE_USERNAME: ${{ secrets.PYPI_USERNAME }}
         TWINE_PASSWORD: ${{ secrets.AMULET_NBT_PYPI_PASSWORD }}
       run: |
-        python -m build --sdist
         twine upload dist/* --skip-existing

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -42,6 +42,8 @@ jobs:
         path: 'lib/Amulet-Compiler-Version'
 
     - name: Build Amulet-Compiler-Version
+      env:
+        BUILD_SPECIALISED: 1
       run: |
         python -m build lib/Amulet-Compiler-Version
 

--- a/.github/workflows/python-unittests.yml
+++ b/.github/workflows/python-unittests.yml
@@ -29,7 +29,6 @@ jobs:
       run: |
         python -m pip install --upgrade pip
         pip install -vv .[dev]
-        pip install pybind11[global]==2.13.6
         pip install Amulet_pybind11_extensions@git+https://github.com/Amulet-Team/Amulet-pybind11-extensions.git@f781177e52f352ea0c1750e9219a1a84f4ddd92f
         python tests/compile.py
     - name: Test with unittest

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,5 @@
+include build_requires.py
+
 recursive-include src/amulet_nbt *.cpp *.hpp *Config.cmake
 
 include CMakeLists.txt

--- a/build_requires.py
+++ b/build_requires.py
@@ -1,0 +1,18 @@
+from typing import Union, Mapping
+
+from setuptools import build_meta
+from setuptools.build_meta import *
+
+
+def get_requires_for_build_wheel(
+    config_settings: Union[Mapping[str, Union[str, list[str], None]], None] = None,
+) -> list[str]:
+    requirements = []
+    requirements.extend(build_meta.get_requires_for_build_wheel(config_settings))
+    requirements.append("wheel")
+    requirements.append("pybind11[global]==2.13.6")
+    if config_settings and config_settings.get("AMULET_FREEZE_COMPILER"):
+        requirements.append(
+            "amulet-compiler-version@git+https://github.com/Amulet-Team/Amulet-Compiler-Version.git@1.0"
+        )
+    return requirements

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,11 +1,10 @@
 [build-system]
 requires = [
-    "setuptools >= 42",
-    "wheel",
+    "setuptools>=42",
     "versioneer",
-    "pybind11[global] == 2.13.6",
 ]
-build-backend = "setuptools.build_meta"
+build-backend = "build_requires"
+backend-path = [""]
 
 [project]
 name = "amulet-nbt"
@@ -14,15 +13,11 @@ authors = [
     {name = "Ben Gothard"},
 ]
 description = "Read and write Minecraft NBT and SNBT data."
-dynamic = ["version", "readme"]
+dynamic = ["version", "readme", "dependencies"]
 requires-python = ">=3.11"
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",
-]
-dependencies = [
-    "amulet-compiler-target == 1.0",
-    "numpy >= 1.17, < 3.0"
 ]
 
 [project.optional-dependencies]
@@ -32,13 +27,14 @@ docs = [
     "sphinx_rtd_theme>=0.3.1",
 ]
 dev = [
+    "setuptools>=42",
+    "versioneer",
+    "wheel",
+    "pybind11[global]==2.13.6",
     "black>=22.3",
     "pre_commit>=1.11.1",
     "mypy",
     "types-pyinstaller",
-    "wheel",
-    "versioneer",
-    "pybind11[global] == 2.13.6",
 ]
 
 [project.urls]

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,6 @@ from setuptools.command.build_ext import build_ext
 
 import versioneer
 
-
 dependencies = [
     "amulet-compiler-target==1.0",
     "numpy>=1.17,<3.0",
@@ -18,9 +17,7 @@ setup_args = {}
 try:
     import amulet_compiler_version
 except ImportError:
-    dependencies.append(
-        "amulet-compiler-version@git+https://github.com/Amulet-Team/Amulet-Compiler-Version.git@1.0"
-    )
+    dependencies.append("amulet-compiler-version==1.1.0")
 else:
     dependencies.append(
         f"amulet-compiler-version=={amulet_compiler_version.__version__}"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,6 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-import pybind11
 
 from setuptools import setup, Extension, Command
 from setuptools.command.build_ext import build_ext
@@ -10,18 +9,35 @@ from setuptools.command.build_ext import build_ext
 import versioneer
 
 
-# https://github.com/pybind/cmake_example/blob/master/setup.py
-class CMakeExtension(Extension):
-    def __init__(self, name: str, sourcedir: str = "") -> None:
-        super().__init__(name, sources=[])
-        self.sourcedir = os.fspath(Path(sourcedir).resolve())
+dependencies = [
+    "amulet-compiler-target==1.0",
+    "numpy>=1.17,<3.0",
+]
+setup_args = {}
 
+try:
+    import amulet_compiler_version
+except ImportError:
+    dependencies.append(
+        "amulet-compiler-version@git+https://github.com/Amulet-Team/Amulet-Compiler-Version.git@1.0"
+    )
+else:
+    dependencies.append(
+        f"amulet-compiler-version=={amulet_compiler_version.__version__}"
+    )
+    setup_args["options"] = {
+        "bdist_wheel": {
+            "build_number": f"1.{amulet_compiler_version.compiler_id}.{amulet_compiler_version.compiler_version}"
+        }
+    }
 
 cmdclass: dict[str, type[Command]] = versioneer.get_cmdclass()
 
 
 class CMakeBuild(cmdclass.get("build_ext", build_ext)):
     def build_extension(self, ext):
+        import pybind11
+
         ext_fullpath = Path.cwd() / self.get_ext_fullpath("")
         src_dir = ext_fullpath.parent.resolve()
 
@@ -63,5 +79,7 @@ cmdclass["build_ext"] = CMakeBuild
 setup(
     version=versioneer.get_version(),
     cmdclass=cmdclass,
-    ext_modules=[CMakeExtension("amulet_nbt._amulet_nbt")],
+    ext_modules=[Extension("amulet_nbt._amulet_nbt", [])],
+    install_requires=dependencies,
+    **setup_args,
 )

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,7 @@ setup_args = {}
 try:
     import amulet_compiler_version
 except ImportError:
-    dependencies.append("amulet-compiler-version==1.1.0")
+    dependencies.append("amulet-compiler-version==1.3.0")
 else:
     dependencies.append(
         f"amulet-compiler-version=={amulet_compiler_version.__version__}"


### PR DESCRIPTION
Added `amulet-compiler-version` dependency. This ensures that pre-compiled packages are compatible with each other.
When the sdist version is compiled on the user's computer it will target the unspecialised version (`1.3.0`) so that it does not consider pre-compiled versions that used a different compiler.
Added a build tag for pre-compiled versions including the compiler id and version to differentiate the same version compiled on different compilers.
