### PR TITLE
Fix build and refactor

### DIFF
--- a/.github/actions/install/action.yml
+++ b/.github/actions/install/action.yml
@@ -5,6 +5,8 @@ inputs:
     description: 'The twine username'
   twine-password:
     description: 'The twine password'
+  compiler-specifier:
+    description: 'The PEP 440 version specifier for the compiler library'
   nbt-specifier:
     description: 'The PEP 440 version specifier for the NBT library'
 outputs:
@@ -19,7 +21,7 @@ runs:
       shell: bash
       continue-on-error: true
       run: |
-        python -m pip install --only-binary amulet-nbt amulet-nbt${{ inputs.nbt-specifier }}
+        python -m pip install --only-binary amulet-nbt amulet-compiler-version${{ inputs.compiler-specifier }} amulet-nbt${{ inputs.nbt-specifier }}
 
     - name: Build
       if: steps.install.outcome == 'failure'

--- a/.github/workflows/python-build.yml
+++ b/.github/workflows/python-build.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.11', '3.12', '3.13']
-        os: [macos-13, windows-latest]
+        os: [macos-14, windows-latest]
 
     runs-on: ${{ matrix.os }}
     defaults:

--- a/build_requires.py
+++ b/build_requires.py
@@ -1,5 +1,4 @@
 from typing import Union, Mapping
-import os
 
 from setuptools import build_meta
 from setuptools.build_meta import *

--- a/requirements.py
+++ b/requirements.py
@@ -11,10 +11,10 @@ AMULET_IO_REQUIREMENT = "~=1.0"
 NUMPY_REQUIREMENT = "~=2.0"
 
 
-def _get_specifier_set(version_str: str, compiler_suffix: str = "") -> str:
+def _get_specifier_set(version_str: str) -> str:
     """
     version_str: The PEP 440 version number of the library.
-    compiler_suffix: Only specified if it is a compiled library and the compiler is being frozen.
+    compiler_suffix_: Only specified if it is a compiled library and the compiler is being frozen.
     """
     version = Version(version_str)
     if version.epoch != 0 or version.is_devrelease or version.is_postrelease:
@@ -22,15 +22,7 @@ def _get_specifier_set(version_str: str, compiler_suffix: str = "") -> str:
 
     major, minor, patch, fix, *_ = version.release + (0, 0, 0, 0)
 
-    if version.is_prerelease:
-        # Pre-releases can make breaking changes. Pin to this exact release.
-        if compiler_suffix:
-            return f"=={major}.{minor}.{patch}.{fix}{compiler_suffix}{''.join(map(str, version.pre))}"
-        else:
-            return f"=={version_str}"
-    else:
-        # Require an ABI compatible build.
-        return f"~={major}.{minor}.{patch}.{fix}"
+    return f"~={major}.{minor}.{patch}.{fix}{''.join(map(str, version.pre or ()))}"
 
 
 if os.environ.get("AMULET_FREEZE_COMPILER", None):

--- a/setup.py
+++ b/setup.py
@@ -83,11 +83,7 @@ def _get_version() -> str:
         )
         if compiler_version_str:
             version = Version(version_str)
-            if (
-                version.epoch != 0
-                or version.is_devrelease
-                or version.is_postrelease
-            ):
+            if version.epoch != 0 or version.is_devrelease or version.is_postrelease:
                 raise RuntimeError(f"Unsupported version format. {version_str}")
             major, minor, patch, fix, *_ = version.release + (0, 0, 0, 0)
             pre = "".join(map(str, version.pre)) if version.is_prerelease else ""

--- a/setup.py
+++ b/setup.py
@@ -2,6 +2,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
+import platform
 
 from setuptools import setup, Extension, Command
 from setuptools.command.build_ext import build_ext
@@ -43,6 +44,9 @@ class CMakeBuild(cmdclass.get("build_ext", build_ext)):
             else:
                 platform_args.extend(["-A", "Win32"])
             platform_args.extend(["-T", "v143"])
+        elif sys.platform == "darwin":
+            if platform.machine() == "arm64":
+                platform_args.append('-DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"')
 
         if subprocess.run(
             [

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,14 @@ import requirements
 import amulet_compiler_version
 
 
+if (
+    os.environ.get("AMULET_FREEZE_COMPILER", None)
+    and sys.platform == "darwin"
+    and platform.machine() != "arm64"
+):
+    raise Exception("The MacOS frozen build must be created on arm64")
+
+
 def fix_path(path: str) -> str:
     return os.path.realpath(path).replace(os.sep, "/")
 

--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ class CMakeBuild(cmdclass.get("build_ext", build_ext)):
             platform_args.extend(["-T", "v143"])
         elif sys.platform == "darwin":
             if platform.machine() == "arm64":
-                platform_args.append('-DCMAKE_OSX_ARCHITECTURES="x86_64;arm64"')
+                platform_args.append('-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64')
 
         if subprocess.run(
             [


### PR DESCRIPTION
Set MacOS multi architecture on arm64.
Require arm64 on MacOS frozen builds.
Add compiler specifier input to install action.