### PR TITLE
Switch to post release

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -94,7 +94,7 @@ def _get_version() -> str:
         epoch = f"{version.epoch}!" if version.epoch else ""
         release = ".".join(map(str, version.release))
         pre = "".join(map(str, version.pre)) if version.is_prerelease else ""
-        post = f".post{datetime.datetime.now().strftime("%Y%m%d%H%M%S")}"
+        post = f".post{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}"
         local = f"+{version.local}" if version.local else ""
         version_str = f"{epoch}{release}{pre}{post}{local}"
 

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ import subprocess
 import sys
 from pathlib import Path
 import platform
+import datetime
 
 from setuptools import setup, Extension, Command
 from setuptools.command.build_ext import build_ext
@@ -54,7 +55,7 @@ class CMakeBuild(cmdclass.get("build_ext", build_ext)):
             platform_args.extend(["-T", "v143"])
         elif sys.platform == "darwin":
             if platform.machine() == "arm64":
-                platform_args.append('-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64')
+                platform_args.append("-DCMAKE_OSX_ARCHITECTURES=x86_64;arm64")
 
         if subprocess.run(
             [
@@ -89,20 +90,13 @@ def _get_version() -> str:
     version_str: str = versioneer.get_version()
 
     if os.environ.get("AMULET_FREEZE_COMPILER", None):
-        # Add the compiler version to the library version so that pip sees it as a distinct version.
-        compiler_version_str = ".".join(
-            amulet_compiler_version.__version__.split(".")[3:]
-        )
-        if compiler_version_str:
-            version = Version(version_str)
-            if version.epoch != 0 or version.is_devrelease or version.is_postrelease:
-                raise RuntimeError(f"Unsupported version format. {version_str}")
-            major, minor, patch, fix, *_ = version.release + (0, 0, 0, 0)
-            pre = "".join(map(str, version.pre)) if version.is_prerelease else ""
-            local = f"+{version.local}" if version.local else ""
-            version_str = (
-                f"{major}.{minor}.{patch}.{fix}.{compiler_version_str}{pre}{local}"
-            )
+        version = Version(version_str)
+        epoch = f"{version.epoch}!" if version.epoch else ""
+        release = ".".join(map(str, version.release))
+        pre = "".join(map(str, version.pre)) if version.is_prerelease else ""
+        post = f".post{datetime.datetime.now().strftime("%Y%m%d%H%M%S")}"
+        local = f"+{version.local}" if version.local else ""
+        version_str = f"{epoch}{release}{pre}{post}{local}"
 
     return version_str
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ from packaging.version import Version
 import versioneer
 
 import requirements
-import amulet_compiler_version
 
 
 if (


### PR DESCRIPTION
This isn't currently an issue with this library but if a dependency needs updating the new version number would be the same and it would create a conflict.
Switching to a unique id per release fixes this.
Making it a post release orders them correctly in the pypi list.