### PR TITLE
Cache timestamp

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -89,11 +89,25 @@ def _get_version() -> str:
     version_str: str = versioneer.get_version()
 
     if os.environ.get("AMULET_FREEZE_COMPILER", None):
+        date_format = "%y%m%d%H%M%S"
+        try:
+            with open("build/timestamp.txt", "r") as f:
+                timestamp = datetime.datetime.strptime(f.read(), date_format)
+            print("using cached timestamp")
+        except Exception:
+            timestamp = datetime.datetime(1, 1, 1)
+        if datetime.timedelta(minutes=10) < datetime.datetime.now() - timestamp:
+            print("get timestamp")
+            timestamp = datetime.datetime.now()
+            os.makedirs("build", exist_ok=True)
+            with open("build/timestamp.txt", "w") as f:
+                f.write(timestamp.strftime(date_format))
+
         version = Version(version_str)
         epoch = f"{version.epoch}!" if version.epoch else ""
         release = ".".join(map(str, version.release))
         pre = "".join(map(str, version.pre)) if version.is_prerelease else ""
-        post = f".post{datetime.datetime.now().strftime('%Y%m%d%H%M%S')}"
+        post = f".post{timestamp.strftime(date_format)}"
         local = f"+{version.local}" if version.local else ""
         version_str = f"{epoch}{release}{pre}{post}{local}"
 


### PR DESCRIPTION
The timestamp can change between executions of setup.py leading to errors.
Cache the timestamp in a file so the same value is used.