### PR TITLE
Reserve memory in utf8 functions

### DIFF
--- a/src/amulet/nbt/string_encoding/mutf8.cpp
+++ b/src/amulet/nbt/string_encoding/mutf8.cpp
@@ -15,6 +15,7 @@ namespace NBT {
     CodePointVector read_mutf8(std::string_view src)
     {
         CodePointVector dst;
+        dst.reserve(src.size());
 
         for (size_t index = 0; index < src.size(); index++) {
             uint8_t b1 = src[index];
@@ -99,6 +100,7 @@ namespace NBT {
 
     void write_mutf8(std::string& dst, const CodePointVector& src)
     {
+        dst.reserve(dst.size() + src.size());
         for (size_t index = 0; index < src.size(); index++) {
             const size_t& c = src[index];
             if (c == 0) {

--- a/src/amulet/nbt/string_encoding/utf8.cpp
+++ b/src/amulet/nbt/string_encoding/utf8.cpp
@@ -27,6 +27,7 @@ namespace NBT {
     CodePointVector _read_utf8(std::string_view src)
     {
         CodePointVector dst;
+        dst.reserve(src.size());
 
         for (size_t index = 0; index < src.size(); index++) {
             uint8_t b1 = src[index];
@@ -177,6 +178,7 @@ namespace NBT {
     template <bool escapeErrors>
     constexpr void _write_utf8(std::string& dst, const CodePointVector& src)
     {
+        dst.reserve(dst.size() + src.size());
         for (size_t index = 0; index < src.size(); index++) {
             const size_t& c = src[index];
             if (c <= 127) {


### PR DESCRIPTION
While profiling I noticed that these functions reallocate a noticeable amount.