### PR TITLE
Fix SNBT encoding of empty keys

### DIFF
--- a/src/amulet/nbt/nbt_encoding/string/write_string.cpp
+++ b/src/amulet/nbt/nbt_encoding/string/write_string.cpp
@@ -223,7 +223,10 @@ namespace NBT {
 
     inline void write_key(std::string& snbt, const StringTag& key)
     {
-        if (std::all_of(key.begin(), key.end(), [](char c) {
+        if (key.empty()) {
+            snbt.append("\"\"");
+        } else if (
+            std::all_of(key.begin(), key.end(), [](char c) {
                 return std::isalnum(c) || c == '.' || c == '_' || c == '+' || c == '-';
             })) {
             snbt.append(key);


### PR DESCRIPTION
If the key is empty it must be surrounded by quotes.