### PR TITLE
Switch to custom mutf8 library

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -21,7 +21,7 @@ zip_safe = False
 python_requires = ~=3.9
 install_requires =
     numpy ~= 1.17
-    mutf8 ~= 1.0
+    amulet-mutf8 ~= 1.0
 
 [options.packages.find]
 where = src

--- a/tests/tags/test_string.py
+++ b/tests/tags/test_string.py
@@ -166,7 +166,7 @@ class TestString(TestWrapper.AbstractBaseTagTest):
         )
         # default string encoder is the Java Modified UTF-8 encoder
         self.assertEqual(
-            b"\x08\x00\x00\x00\x06\xed\xa1\xbc\xed\xbf\xb9",
+            b"\x08\x00\x00\x00\x06\xed\xa0\xbc\xed\xbf\xb9",
             StringTag("🏹").to_nbt(compressed=False, little_endian=False),
         )
         self.assertEqual(
@@ -225,7 +225,7 @@ class TestString(TestWrapper.AbstractBaseTagTest):
         self.assertStrictEqual(
             StringTag("🏹"),
             load_nbt(
-                b"\x08\x00\x00\x00\x06\xed\xa1\xbc\xed\xbf\xb9",
+                b"\x08\x00\x00\x00\x06\xed\xa0\xbc\xed\xbf\xb9",
                 compressed=False,
                 little_endian=False,
             ).string,


### PR DESCRIPTION
The mutf8 library had a bug with 6-byte surrogate pair characters. I submitted a fix some years ago but it has not been merged. This is a fork of the original with a patch.